### PR TITLE
New schema field syntax

### DIFF
--- a/lib/plumb/schema.rb
+++ b/lib/plumb/schema.rb
@@ -75,14 +75,14 @@ module Plumb
       freeze
     end
 
-    def field(key)
+    def field(key, type = nil, &block)
       key = Key.new(key.to_sym)
-      @fields[key] = Field.new(key)
+      @fields[key] = Field.new(key, type, &block)
     end
 
-    def field?(key)
+    def field?(key, type = nil, &block)
       key = Key.new(key.to_sym, optional: true)
-      @fields[key] = Field.new(key)
+      @fields[key] = Field.new(key, type, &block)
     end
 
     def +(other)
@@ -117,32 +117,23 @@ module Plumb
 
       attr_reader :_type, :key
 
-      def initialize(key)
+      def initialize(key, type = nil, &block)
         @key = key.to_sym
-        @_type = Types::Any
+        @_type = case type
+                 when ArrayClass, Array
+                   block_given? ? ArrayClass.new(element_type: Schema.new(&block)) : type
+                 when nil
+                   block_given? ? Schema.new(&block) : Types::Any
+                 when Steppable
+                   type
+                 when Class
+                   Types::Any[type]
+                 else
+                   raise ArgumentError, "expected a Plumb type, but got #{type.inspect}"
+                 end
       end
 
       def call(result) = _type.call(result)
-
-      def type(steppable)
-        unless steppable.respond_to?(:call)
-          raise ArgumentError,
-            "expected a Plumb type, but got #{steppable.inspect}"
-        end
-
-        @_type >>= steppable
-        self
-      end
-
-      def schema(...)
-        @_type >>= Schema.wrap(...)
-        self
-      end
-
-      def array(...)
-        @_type >>= Types::Array[Schema.wrap(...)]
-        self
-      end
 
       def default(v, &block)
         @_type = @_type.default(v, &block)
@@ -161,8 +152,8 @@ module Plumb
         self
       end
 
-      def optional
-        @_type = Types::Nil | @_type
+      def nullable
+        @_type = @_type.nullable
         self
       end
 

--- a/lib/plumb/schema.rb
+++ b/lib/plumb/schema.rb
@@ -148,7 +148,7 @@ module Plumb
       def metadata = @_type.metadata
 
       def options(opts)
-        @_type = @_type.rule(included_in: opts)
+        @_type = @_type.options(opts)
         self
       end
 
@@ -164,6 +164,11 @@ module Plumb
 
       def required
         @_type = Types::Undefined.invalid(errors: 'is required') >> @_type
+        self
+      end
+
+      def match(matcher)
+        @_type = @_type.match(matcher)
         self
       end
 

--- a/spec/schema_spec.rb
+++ b/spec/schema_spec.rb
@@ -326,6 +326,12 @@ RSpec.describe Plumb::Schema do
     assert_result(field.resolve, [], true)
   end
 
+  specify 'Field#match' do
+    field = described_class::Field.new(:age, Integer).match(21..)
+    assert_result(field.resolve(22), 22, true)
+    assert_result(field.resolve(20), 20, false)
+  end
+
   specify 'self-contained Array type' do
     array_type = Types::Array[Types::Integer | Types::String.transform(::Integer, &:to_i)]
     schema = described_class.new do |sc|


### PR DESCRIPTION
Change schema definition syntax to:

```ruby
User = Schema.new do |sc|
  sc.field :name, Types::String.default('Joe')
  sc.field :email, Types::Email
  # Map [] to Types::Array?
  sc.field :friends, [] do |friend|
    friend.field :name, Types::String
  end
  # or
  sc.field :friends, Types::Array[Friend]
  
  # Nested schema
  sc.field :friend do |fr|
    fr.field :name, Types::String
  end
end
```

Also support passing primitives as types (will be wrapped by `Types::Any[primitive]`. Example

```ruby
Plumb::Schema.new do |sc|
  sc.field :name, String
  sc.field :age, Integer
end
```

Fields still have methods like `#default`, `#rule`, `#match`, so these are equivalent:

```ruby
sc.field(:age, Integer).match(21..)
sc.field :age, Types::Integer.match(21..)
```