### PR TITLE
Wrap primitive classes

### DIFF
--- a/README.md
+++ b/README.md
@@ -399,8 +399,8 @@ intersection = User & Employee # Hash[:name]
 Use `#tagged_by` to resolve what definition to use based on the value of a common key.
 
 ```ruby
-NameUpdatedEvent = Types::Hash[type: 'name_updated', name: Types::String]
-AgeUpdatedEvent = Types::Hash[type: 'age_updated', age: Types::Integer]
+NameUpdatedEvent = Types::Hash[type: Types::Static['name_updated'], name: Types::String]
+AgeUpdatedEvent = Types::Hash[type: Types::Static['age_updated'], age: Types::Integer]
 
 Events = Types::Hash.tagged_by(
   :type,

--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ Note that this is syntax sugar for:
 
 ```ruby
 # A String, or if it's Undefined pipe to a static string value.
-str = Types::String | (Types::Undefined >> 'nope'.freeze)
+str = Types::String | (Types::Undefined >> Types::Static['nope'.freeze])
 ```
 
 Meaning that you can compose your own semantics for a "default" value.
@@ -192,7 +192,7 @@ Meaning that you can compose your own semantics for a "default" value.
 Example when you want to apply a default when the given value is `nil`.
 
 ```ruby
-str = Types::String | (Types::Nil >> 'nope'.freeze)
+str = Types::String | (Types::Nil >> Types::Static['nope'.freeze])
 
 str.parse(nil) # 'nope'
 str.parse('yup') # 'yup'
@@ -370,6 +370,42 @@ result.valid? # false
 result.errors[:employees][0][:age] # ["must be a Numeric"]
 ```
 
+Note that you can use primitives as hash field definitions.
+
+```ruby
+User = Types::Hash[name: String, age: Integer]
+```
+
+Or to validate specific values:
+
+```ruby
+Joe = Types::Hash[name: 'Joe', age: Integer]
+```
+
+Or to validate against any `#===` interface:
+
+```ruby
+Adult = Types::Hash[name: String, age: (18..)]
+# Same as
+Adult = Types::Hash[name: Types::String, age: Types::Integer[18..]]
+```
+
+If you want to validate literal values, pass a `Types::Value`
+
+```ruby
+Settings = Types::hash[age_range: Types::Value[18..]]
+
+Settings.parse(age_range: (18..)) # Valid
+Settings.parse(age_range: (20..30)) # Invalid
+```
+
+A `Types::Static` value will always resolve successfully to that value, regardless of the original payload.
+
+```ruby
+User = Types::Hash[name: Types::Static['Joe'], age: Integer]
+User.parse(name: 'Rufus', age: 34) # Valid {name: 'Joe', age: 34}
+```
+
 
 
 #### Merging hash definitions
@@ -398,6 +434,8 @@ intersection = User & Employee # Hash[:name]
 
 Use `#tagged_by` to resolve what definition to use based on the value of a common key.
 
+Key used as index must be a `Types::Static`
+
 ```ruby
 NameUpdatedEvent = Types::Hash[type: Types::Static['name_updated'], name: Types::String]
 AgeUpdatedEvent = Types::Hash[type: Types::Static['age_updated'], age: Types::Integer]
@@ -424,6 +462,26 @@ currencies.parse(usd: 'USD', gbp: 'GBP') # Ok
 currencies.parse('usd' => 'USD') # Error. Keys must be Symbols
 ```
 
+Like other types, hash maps accept primitive types as keys and values:
+
+```ruby
+currencies = Types::Hash[Symbol, String]
+```
+
+And any `#===` interface as values, too:
+
+```ruby
+names_and_emails = Types::Hash[String, /\w+@\w+/]
+
+names_and_emails.parse('Joe' => 'joe@server.com', 'Rufus' => 'rufus')
+```
+
+Use `Types::Value` to validate specific values (using `#==`)
+
+```ruby
+names_and_ones = Types::Hash[String, Types::Integer.value(1)]
+```
+
 
 
 ### `Types::Array`
@@ -432,6 +490,17 @@ currencies.parse('usd' => 'USD') # Error. Keys must be Symbols
 names = Types::Array[Types::String.present]
 names_or_ages = Types::Array[Types::String.present | Types::Integer[21..]]
 ```
+
+Arrays support primitive classes, or any `#===` interface:
+
+```ruby
+strings = Types::Array[String]
+emails = Types::Array[/@/]
+# Similar to 
+emails = Types::Array[Types::String[/@/]]
+```
+
+Prefer the latter (`Types::Array[Types::String[/@/]]`), as that first validates that each element is a `String` before matching agains the regular expression.
 
 #### Concurrent arrays
 
@@ -470,6 +539,18 @@ Note that literal values can be used too.
 Ok = Types::Tuple[:ok, nil]
 Error = Types::Tuple[:error, Types::String.present]
 Status = Ok | Error
+```
+
+... Or any `#===` interface
+
+```ruby
+NameAndEmail = Types::Tuple[String, /@/]
+```
+
+As before, use `Types::Value` to check against literal values using `#==`
+
+```ruby
+NameAndRegex = Types::Tuple[String, Types::Value[/@/]]
 ```
 
 

--- a/lib/plumb/array_class.rb
+++ b/lib/plumb/array_class.rb
@@ -13,14 +13,13 @@ module Plumb
 
     def initialize(element_type: Types::Any)
       @element_type = case element_type
-      when Steppable
-        element_type
-      when ::Hash
-        HashClass.new(element_type)
-      else
-        raise ArgumentError,
-          "element_type #{element_type.inspect} must be a Steppable"
-      end
+                      when Steppable
+                        element_type
+                      when ::Hash
+                        HashClass.new(element_type)
+                      else
+                        Steppable.wrap(element_type)
+                      end
 
       freeze
     end
@@ -73,12 +72,12 @@ module Plumb
         errors = {}
 
         values = list
-          .map { |e| Concurrent::Future.execute { element_type.resolve(e) } }
-          .map.with_index do |f, idx|
-            re = f.value
-            errors[idx] = f.reason if f.rejected?
-            re.value
-          end
+                 .map { |e| Concurrent::Future.execute { element_type.resolve(e) } }
+                 .map.with_index do |f, idx|
+          re = f.value
+          errors[idx] = f.reason if f.rejected?
+          re.value
+        end
 
         [values, errors]
       end

--- a/lib/plumb/hash_class.rb
+++ b/lib/plumb/hash_class.rb
@@ -29,8 +29,10 @@ module Plumb
       case args
       in [::Hash => hash]
         self.class.new(_schema.merge(wrap_keys_and_values(hash)))
-      in [Steppable => key_type, Steppable => value_type]
-        HashMap.new(key_type, value_type)
+      in [Steppable => key_type, value_type]
+        HashMap.new(key_type, Steppable.wrap(value_type))
+      in [Class => key_type, value_type]
+        HashMap.new(Steppable.wrap(key_type), Steppable.wrap(value_type))
       else
         raise ::ArgumentError, "unexpected value to Types::Hash#schema #{args.inspect}"
       end

--- a/lib/plumb/json_schema_visitor.rb
+++ b/lib/plumb/json_schema_visitor.rb
@@ -97,6 +97,8 @@ module Plumb
     end
 
     on(:static) do |node, props|
+      # Set const AND default
+      # to emulate static values
       props = case node.value
               when ::String, ::Symbol, ::Numeric
                 props.merge(CONST => node.value, DEFAULT => node.value)
@@ -118,6 +120,14 @@ module Plumb
     end
 
     on(:match) do |node, props|
+      # Set const if primitive
+      props = case node.matcher
+              when ::String, ::Symbol, ::Numeric
+                props.merge(CONST => node.matcher)
+              else
+                props
+              end
+
       visit(node.matcher, props)
     end
 

--- a/lib/plumb/steppable.rb
+++ b/lib/plumb/steppable.rb
@@ -46,7 +46,7 @@ module Plumb
 
     def self.included(base)
       nname = base.name.split('::').last
-      nname.gsub!(/([a-z\d])([A-Z])/,'\1_\2')
+      nname.gsub!(/([a-z\d])([A-Z])/, '\1_\2')
       nname.downcase!
       nname.gsub!(/_class$/, '')
       nname = nname.to_sym
@@ -58,10 +58,8 @@ module Plumb
         callable
       elsif callable.respond_to?(:call)
         Step.new(callable)
-      elsif callable.is_a?(::Class)
-        MatchClass.new(callable)
       else
-        StaticClass.new(callable)
+        MatchClass.new(callable)
       end
     end
 
@@ -147,10 +145,10 @@ module Plumb
 
     def default(val = Undefined, &block)
       val_type = if val == Undefined
-        DefaultProc.call(block)
-      else
-        Types::Static[val]
-      end
+                   DefaultProc.call(block)
+                 else
+                   Types::Static[val]
+                 end
 
       self | (Types::Undefined >> val_type)
     end
@@ -188,13 +186,13 @@ module Plumb
 
     def rule(*args)
       specs = case args
-        in [::Symbol => rule_name, value]
-        { rule_name => value }
-        in [::Hash => rules]
-        rules
-      else
-        raise ArgumentError, "expected 1 or 2 arguments, but got #{args.size}"
-      end
+              in [::Symbol => rule_name, value]
+                { rule_name => value }
+              in [::Hash => rules]
+                rules
+              else
+                raise ArgumentError, "expected 1 or 2 arguments, but got #{args.size}"
+              end
 
       self >> Rules.new(specs, metadata[:type])
     end

--- a/lib/plumb/tuple_class.rb
+++ b/lib/plumb/tuple_class.rb
@@ -9,7 +9,7 @@ module Plumb
     attr_reader :types
 
     def initialize(*types)
-      @types = types.map { |t| t.is_a?(Steppable) ? t : Types::Any.value(t) }
+      @types = types.map { |t| Steppable.wrap(t) }
     end
 
     def of(*types)
@@ -17,10 +17,6 @@ module Plumb
     end
 
     alias [] of
-
-    private def _inspect
-      "#{name}[#{@types.map(&:inspect).join(', ')}]"
-    end
 
     def call(result)
       return result.invalid(errors: 'must be an Array') unless result.value.is_a?(::Array)
@@ -37,6 +33,12 @@ module Plumb
       return result.valid(values) unless errors.any?
 
       result.invalid(errors:)
+    end
+
+    private
+
+    def _inspect
+      "#{name}[#{@types.map(&:inspect).join(', ')}]"
     end
   end
 end

--- a/spec/json_schema_visitor_spec.rb
+++ b/spec/json_schema_visitor_spec.rb
@@ -93,10 +93,10 @@ RSpec.describe Plumb::JSONSchemaVisitor do
       type = Types::String.default('foo')
       expect(described_class.visit(type)).to eq('type' => 'string', 'default' => 'foo')
 
-      type = Types::String | (Types::Undefined >> 'bar')
+      type = Types::String | (Types::Undefined >> Types::Static['bar'])
       expect(described_class.visit(type)).to eq('type' => 'string', 'default' => 'bar')
 
-      type = (Types::Undefined >> 'bar2') | Types::String
+      type = (Types::Undefined >> Types::Static['bar2']) | Types::String
       expect(described_class.visit(type)).to eq('type' => 'string', 'default' => 'bar2')
     end
 
@@ -210,10 +210,10 @@ RSpec.describe Plumb::JSONSchemaVisitor do
 
     specify 'Types::Hash.tagged_by' do
       t1 = Types::Hash[
-        kind: 't1', name: Types::String,
+        kind: Types::Static['t1'], name: Types::String,
         age: Types::Integer
       ]
-      t2 = Types::Hash[kind: 't2', name: Types::String]
+      t2 = Types::Hash[kind: Types::Static['t2'], name: Types::String]
       type = Types::Hash.tagged_by(:kind, t1, t2)
 
       expect(described_class.visit(type)).to eq(

--- a/spec/types_spec.rb
+++ b/spec/types_spec.rb
@@ -818,6 +818,12 @@ RSpec.describe Plumb::Types do
         assert_result(s1.present.resolve({}), {}, false)
       end
 
+      specify 'hash map with primitive values and classes' do
+        s1 = Types::Hash[::String, ::Integer]
+        assert_result(s1.resolve('ok' => 1, 'foo' => 2), { 'ok' => 1, 'foo' => 2 }, true)
+        assert_result(s1.resolve(:ok => 1, 'foo' => 2), { :ok => 1, 'foo' => 2 }, false)
+      end
+
       specify '#[] alias to #schema' do
         s1 = Types::Hash[Types::String, Types::Integer]
         expect(s1.metadata).to eq(type: Hash)

--- a/spec/types_spec.rb
+++ b/spec/types_spec.rb
@@ -537,6 +537,12 @@ RSpec.describe Plumb::Types do
           false
         )
       end
+
+      specify 'with primitive classes' do
+        type = Types::Tuple[::String, ::Integer]
+        assert_result(type.resolve(['Ismael', 42]), ['Ismael', 42], true)
+        assert_result(type.resolve([23, 42]), [23, 42], false)
+      end
     end
 
     describe Types::Array do
@@ -652,8 +658,8 @@ RSpec.describe Plumb::Types do
       specify '#schema with static values' do
         hash = Types::Hash.schema(
           title: Types::String.default('Mr'),
-          name: 'Ismael',
-          age: 45,
+          name: Types::Static['Ismael'],
+          age: Types::Static[45],
           friend: Types::Hash.schema(name: Types::String)
         )
 
@@ -759,8 +765,8 @@ RSpec.describe Plumb::Types do
       end
 
       specify '#tagged_by' do
-        t1 = Types::Hash[kind: 't1', name: Types::String]
-        t2 = Types::Hash[kind: 't2', name: Types::String]
+        t1 = Types::Hash[kind: Types::Static['t1'], name: Types::String]
+        t2 = Types::Hash[kind: Types::Static['t2'], name: Types::String]
         type = Types::Hash.tagged_by(:kind, t1, t2)
 
         assert_result(type.resolve(kind: 't1', name: 'T1'), { kind: 't1', name: 'T1' }, true)

--- a/spec/types_spec.rb
+++ b/spec/types_spec.rb
@@ -588,10 +588,15 @@ RSpec.describe Plumb::Types do
         assert_result(type.resolve([{ foo: 'bar' }]), [{ foo: 'bar' }], true)
       end
 
-      specify '#[] (#of) with non-steppable argument' do
-        expect do
-          Types::Array['bar']
-        end.to raise_error(ArgumentError)
+      specify '#[] with primitive values' do
+        type = Types::Array[::String]
+        assert_result(type.resolve(%w[Ismael Joe]), %w[Ismael Joe], true)
+      end
+
+      specify '#[] (#of) with literal argument' do
+        type = Types::Array['bar']
+        assert_result(type.resolve(%w[bar]), %w[bar], true)
+        assert_result(type.resolve(%w[foo]), %w[foo], false)
       end
 
       specify '#present (non-empty)' do


### PR DESCRIPTION
Allow using primitive classes and `#===` interfaces as type definitions.

```ruby
User = Types::Hash[name: String, age: Integer]
```

```ruby
Joe = Types::Hash[name: 'Joe', age: Integer]
```

```ruby
Adult = Types::Hash[name: String, age: (18..)]
# Same as
Adult = Types::Hash[name: Types::String, age: Types::Integer[18..]]
```

Works for arrays, hash maps, hashes, tuples.