### PR TITLE
Types::Hash#inclusive

### DIFF
--- a/lib/plumb/array_class.rb
+++ b/lib/plumb/array_class.rb
@@ -16,7 +16,7 @@ module Plumb
                       when Steppable
                         element_type
                       when ::Hash
-                        HashClass.new(element_type)
+                        HashClass.new(schema: element_type)
                       else
                         Steppable.wrap(element_type)
                       end

--- a/spec/types_spec.rb
+++ b/spec/types_spec.rb
@@ -825,6 +825,14 @@ RSpec.describe Plumb::Types do
         expect(s1.metadata).to eq(type: Hash)
         assert_result(s1.resolve('a' => 1, 'b' => 2), { 'a' => 1, 'b' => 2 }, true)
       end
+
+      specify '#inclusive' do
+        exclusive = Types::Hash[age: Types::Lax::Integer]
+        inclusive = exclusive.inclusive
+        data = { name: 'Joe', age: '10' }
+        assert_result(exclusive.resolve(data), { age: 10 }, true)
+        assert_result(inclusive.resolve(data), { name: 'Joe', age: 10 }, true)
+      end
     end
   end
 


### PR DESCRIPTION
#### `Types::Hash#inclusive`

Use `#inclusive` to preserve input keys not defined in the hash schema.

```ruby
hash = Types::Hash[age: Types::Lax::Integer].inclusive

# Only :age, is coerced and validated, all other keys are preserved as-is
hash.parse(age: '30', name: 'Joe', last_name: 'Bloggs') # { age: 30, name: 'Joe', last_name: 'Bloggs' }
```

This can be useful if you only care about validating some fields, or to assemble different front and back hashes. For example a client-facing one that validates JSON or form data, and a backend one that runs further coercions or domain validations on some keys.

```ruby
# Front-end definition does structural validation
Front = Types::Hash[price: Integer, name: String, category: String]

# Turn an Integer into a Money instance
IntToMoney = Types::Integer.transform(Money) { |cents| Money.new(cents, 'GBP') }

# Backend definition turns :price into a Money object, leaves other keys as-is
Back = Types::Hash[price: IntToMoney].inclusive

# Compose the pipeline
InputHandler = Front >> Back

InputHandler.parse(price: 100_000, name: 'iPhone 15', category: 'smartphones')
# => { price: #<Money fractional:100000 currency:GBP>, name: 'iPhone 15', category: 'smartphone' }
```