### PR TITLE
Steppable#invoke

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,39 @@ StringToInt = Types::String.transform(Integer, &:to_i)
 StringToInteger.parse('10') # => 10
 ```
 
+The target type is required so that it's added to resulting metadata, JSON Schema, and any other type reflection.
+
+```ruby
+StringToInt.metadata[:type] # Integer
+```
+
+
+
+### `#invoke`
+
+`#invoke` registers a method and optional arguments to be called on the value.
+
+```ruby
+StringToInt = Types::String.invoke(:to_i)
+StringToInt.parse('100') # 100
+
+FilteredHash = Types::Hash.invoke(:except, :foo, :bar)
+FilteredHash.parse(foo: 1, bar: 2, name: 'Joe') # { name: 'Joe' }
+
+# It works with blocks
+Evens = Types::Array[Integer].invoke(:filter, &:even?)
+Evens.parse([1,2,3,4,5]) # [2, 4]
+
+# Same as
+Evens = Types::Array[Integer].transform(Array) {|arr| arr.filter(&:even?) }
+```
+
+Note that `#invoke` does not set `#metadata[:type]`, so you might end up with unexpected metadata if you're not careful.
+
+```ruby
+StringToInt.metadata[:type] # String, not Integer
+```
+
 
 
 ### `#default`

--- a/lib/plumb/step.rb
+++ b/lib/plumb/step.rb
@@ -8,9 +8,10 @@ module Plumb
 
     attr_reader :_metadata
 
-    def initialize(callable = nil, &block)
+    def initialize(callable = nil, inspect = nil, &block)
       @_metadata = callable.respond_to?(:metadata) ? callable.metadata : BLANK_HASH
       @callable = callable || block
+      @inspect = inspect || @callable.inspect
       freeze
     end
 
@@ -20,6 +21,6 @@ module Plumb
 
     private
 
-    def _inspect = "Step[#{@callable.inspect}]"
+    def _inspect = "Step[#{@inspect}]"
   end
 end

--- a/lib/plumb/steppable.rb
+++ b/lib/plumb/steppable.rb
@@ -216,6 +216,22 @@ module Plumb
     def to_s
       inspect
     end
+
+    # @param method_name [Symbol] method to invoke on the value
+    # @param args [Array] arguments to pass to the method, if any
+    # @yield block
+    # @return [Step]
+    def invoke(method_name, *args, &block)
+      types = Array(metadata[:type]).uniq
+      unless types.size == 1 && types.first.is_a?(Class) && types.first.instance_methods.include?(method_name)
+        raise NoMethodError, "#{types.first.inspect} does not respond to `#{method_name}'"
+      end
+
+      self >> Step.new(
+        ->(result) { result.valid(result.value.public_send(method_name, *args, &block)) },
+        [method_name.inspect, args.inspect].join(' ')
+      )
+    end
   end
 end
 

--- a/spec/types_spec.rb
+++ b/spec/types_spec.rb
@@ -90,6 +90,20 @@ RSpec.describe Plumb::Types do
     end
   end
 
+  describe '#invoke' do
+    it 'invokes methods on values' do
+      expect(Types::String.invoke(:to_i).parse('100')).to eq(100)
+      expect(Types::Hash.invoke(:except, :foo).parse(foo: 1, bar: 2)).to eq(bar: 2)
+      expect(Types::Array.invoke(:filter, &:even?).parse((0..10).to_a)).to eq([0, 2, 4, 6, 8, 10])
+    end
+
+    it 'raises if :type does not support method' do
+      expect do
+        Types::String.invoke(:nope)
+      end.to raise_error(NoMethodError, "String does not respond to `nope'")
+    end
+  end
+
   specify Types::Static do
     assert_result(Types::Static['hello'].resolve('hello'), 'hello', true)
     assert_result(Types::Static['hello'].resolve('nope'), 'hello', true)


### PR DESCRIPTION
### `#invoke`

`#invoke` registers a method and optional arguments to be called on the value.

```ruby
StringToInt = Types::String.invoke(:to_i)
StringToInt.parse('100') # 100

FilteredHash = Types::Hash.invoke(:except, :foo, :bar)
FilteredHash.parse(foo: 1, bar: 2, name: 'Joe') # { name: 'Joe' }

# It works with blocks
Evens = Types::Array[Integer].invoke(:filter, &:even?)
Evens.parse([1,2,3,4,5]) # [2, 4]

# Same as
Evens = Types::Array[Integer].transform(Array) {|arr| arr.filter(&:even?) }
```

Note that `#invoke` does not set `#metadata[:type]`, so you might end up with unexpected metadata if you're not careful.

```ruby
StringToInt.metadata[:type] # String, not Integer
```
