### PR TITLE
Array filtered

### DIFF
--- a/README.md
+++ b/README.md
@@ -541,17 +541,6 @@ Use `Types::Value` to validate specific values (using `#==`)
 names_and_ones = Types::Hash[String, Types::Integer.value(1)]
 ```
 
-#### `#filtered`
-
-Calling the `#filtered` modifier on a Hash Map makes it return a sub set of the keys and values that are valid as per the key and value type definitions.
-
-```ruby
-# Filter the ENV for all keys starting with S3_*
-S3Config = Types::Hash[/^S3_\w+/, Types::Any].filtered
-
-S3Config.parse(ENV.to_h) # { 'S3_BUCKET' => 'foo', 'S3_REGION' => 'us-east-1' }
-```
-
 
 
 ### `Types::Array`
@@ -598,6 +587,17 @@ TODO: pluggable concurrency engines (Async?)
 Turn an Array definition into an enumerator that yields each element wrapped in `Result::Valid` or `Result::Invalid`.
 
 See `Types::Stream` below for more.
+
+#### `#filtered`
+
+The `#filtered` modifier makes an array definition return a subset of the input array where the values are valid, as per the array's element type.
+
+```ruby
+j_names = Types::Array[Types::String[/^j/]].filtered
+j_names.parse(%w[james ismael joe toby joan isabel]) # ["james", "joe", "joan"]
+```
+
+
 
 ### `Types::Tuple`
 

--- a/lib/plumb/array_class.rb
+++ b/lib/plumb/array_class.rb
@@ -31,6 +31,16 @@ module Plumb
       StreamClass.new(element_type:)
     end
 
+    def filtered
+      MatchClass.new(::Array) >> Step.new(nil, "Array[#{element_type}].filtered") do |result|
+        arr = result.value.each.with_object([]) do |e, memo|
+          r = element_type.resolve(e)
+          memo << r.value if r.valid?
+        end
+        result.valid(arr)
+      end
+    end
+
     def call(result)
       return result.invalid(errors: 'is not an Array') unless ::Array === result.value
 

--- a/spec/types_spec.rb
+++ b/spec/types_spec.rb
@@ -660,6 +660,11 @@ RSpec.describe Plumb::Types do
       results = stream.parse([1, 2, 'd', 4])
       expect(results.map(&:valid?)).to eq([true, true, false, true])
     end
+
+    specify '#filtered' do
+      array = Types::Array[String].filtered
+      expect(array.parse([1, 'a', 2, 'b', 'c', 3])).to eq(%w[a b c])
+    end
   end
 
   describe Types::Hash do


### PR DESCRIPTION
#### `Types::Array#filtered`

The `#filtered` modifier makes an array definition return a subset of the input array where the values are valid, as per the array's element type.

```ruby
j_names = Types::Array[Types::String[/^j/]].filtered
j_names.parse(%w[james ismael joe toby joan isabel]) # ["james", "joe", "joan"]
```