### PR TITLE
Single metadata method

### DIFF
--- a/README.md
+++ b/README.md
@@ -443,19 +443,21 @@ All scalar types support this:
 ten = Types::Integer.value(10)
 ```
 
-### `#meta` and `#metadata`
+### `#metadata`
 
 Add metadata to a type
 
 ```ruby
-type = Types::String.meta(description: 'A long text')
+# A new type with metadata
+type = Types::String.metadata(description: 'A long text')
+# Read a type's metadata
 type.metadata[:description] # 'A long text'
 ```
 
 `#metadata` combines keys from type compositions.
 
 ```ruby
-type = Types::String.meta(description: 'A long text') >> Types::String.match(/@/).meta(note: 'An email address')
+type = Types::String.metadata(description: 'A long text') >> Types::String.match(/@/).metadata(note: 'An email address')
 type.metadata[:description] # 'A long text'
 type.metadata[:note] # 'An email address'
 ```

--- a/lib/plumb/composable.rb
+++ b/lib/plumb/composable.rb
@@ -23,10 +23,6 @@ module Plumb
   NOOP = ->(result) { result }
 
   module Callable
-    def metadata
-      MetadataVisitor.call(self)
-    end
-
     def resolve(value = Undefined)
       call(Result.wrap(value))
     end
@@ -115,8 +111,12 @@ module Plumb
       self >> MatchClass.new(block, error: errors, label: errors)
     end
 
-    def meta(data = {})
-      self >> Metadata.new(data)
+    def metadata(data = Undefined)
+      if data == Undefined
+        MetadataVisitor.call(self)
+      else
+        self >> Metadata.new(data)
+      end
     end
 
     def not(other = self)

--- a/lib/plumb/schema.rb
+++ b/lib/plumb/schema.rb
@@ -140,12 +140,13 @@ module Plumb
         self
       end
 
-      def meta(md = nil)
-        @_type = @_type.meta(md) if md
-        self
+      def metadata(data = Undefined)
+        if data == Undefined
+          @_type.metadata
+        else
+          @_type = @_type.metadata(data)
+        end
       end
-
-      def metadata = @_type.metadata
 
       def options(opts)
         @_type = @_type.options(opts)

--- a/spec/json_schema_visitor_spec.rb
+++ b/spec/json_schema_visitor_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Plumb::JSONSchemaVisitor do
 
   specify 'simplest possible case with one-level keys and types' do
     type = Types::Hash[
-      name: Types::String.meta(description: 'the name'),
+      name: Types::String.metadata(description: 'the name'),
       age?: Types::Integer
     ]
 

--- a/spec/schema_spec.rb
+++ b/spec/schema_spec.rb
@@ -323,7 +323,7 @@ RSpec.describe Plumb::Schema do
   end
 
   specify 'Field#meta' do
-    field = described_class::Field.new(:name, Types::String).meta(foo: 1).meta(bar: 2)
+    field = described_class::Field.new(:name, Types::String).metadata(foo: 1).metadata(bar: 2)
     expect(field.metadata).to eq(type: ::String, foo: 1, bar: 2)
     expect(field.metadata).to eq(field.metadata)
   end

--- a/spec/types_spec.rb
+++ b/spec/types_spec.rb
@@ -188,31 +188,31 @@ RSpec.describe Plumb::Types do
     expect(failed.errors).to eq(['Must be a String', 'Must be a Integer'])
   end
 
-  specify '#meta' do
-    to_s = Types::Any.transform(::String, &:to_s).meta(type: :string)
-    to_i = Types::Any.transform(::Integer, &:to_i).meta(type: :integer).meta(foo: 'bar')
+  specify '#metadata as a setter' do
+    to_s = Types::Any.transform(::String, &:to_s).metadata(type: :string)
+    to_i = Types::Any.transform(::Integer, &:to_i).metadata(type: :integer).metadata(foo: 'bar')
     pipe = to_s >> to_i
     expect(to_s.metadata[:type]).to eq(:string)
     expect(pipe.metadata[:type]).to eq(:integer)
     expect(pipe.metadata[:foo]).to eq('bar')
   end
 
-  describe '#metadata' do
+  describe '#metadata as a getter' do
     specify 'AND (>>) chains' do
-      type = Types::String >> Types::Integer.meta(foo: 'bar')
+      type = Types::String >> Types::Integer.metadata(foo: 'bar')
       expect(type.metadata).to eq({ type: ::Integer, foo: 'bar' })
     end
 
     specify 'OR (|) chains' do
-      type = Types::String | Types::Integer.meta(foo: 'bar')
+      type = Types::String | Types::Integer.metadata(foo: 'bar')
       expect(type.metadata).to eq({ type: [::String, ::Integer], foo: 'bar' })
     end
 
     specify 'AND (>>) with OR (|)' do
-      type = Types::String >> (Types::Integer | Types::Boolean).meta(foo: 'bar')
+      type = Types::String >> (Types::Integer | Types::Boolean).metadata(foo: 'bar')
       expect(type.metadata).to eq({ type: [::Integer, 'boolean'], foo: 'bar' })
 
-      type = Types::String | (Types::Integer >> Types::Boolean).meta(foo: 'bar')
+      type = Types::String | (Types::Integer >> Types::Boolean).metadata(foo: 'bar')
       expect(type.metadata).to eq({ type: [::String, 'boolean'], foo: 'bar' })
     end
   end
@@ -264,7 +264,7 @@ RSpec.describe Plumb::Types do
     end
 
     specify '#metadata' do
-      pipe = pipeline.meta(foo: 'bar')
+      pipe = pipeline.metadata(foo: 'bar')
       expect(pipe.metadata).to include({ type: Integer, foo: 'bar' })
     end
 
@@ -619,7 +619,7 @@ RSpec.describe Plumb::Types do
     end
 
     specify '#metadata' do
-      type = Types::Array[Types::Boolean].meta(foo: 1)
+      type = Types::Array[Types::Boolean].metadata(foo: 1)
       expect(type.metadata).to eq(type: Array, foo: 1)
     end
 


### PR DESCRIPTION
Merge the previous "setter" `#meta` and getter `#metadata` into a single `#metadata` helper.

```ruby
# New type with metadata
type = Types::String.metadata(description: 'a string')

# Get type metadata
type.metadata #=> { description: 'a string' }
```