### PR TITLE
Uniform #children array

### DIFF
--- a/lib/plumb/and.rb
+++ b/lib/plumb/and.rb
@@ -6,7 +6,7 @@ module Plumb
   class And
     include Composable
 
-    attr_reader :left, :right, :children
+    attr_reader :children
 
     def initialize(left, right)
       @left = left

--- a/lib/plumb/and.rb
+++ b/lib/plumb/and.rb
@@ -6,11 +6,12 @@ module Plumb
   class And
     include Composable
 
-    attr_reader :left, :right
+    attr_reader :left, :right, :children
 
     def initialize(left, right)
       @left = left
       @right = right
+      @children = [left, right].freeze
       freeze
     end
 

--- a/lib/plumb/array_class.rb
+++ b/lib/plumb/array_class.rb
@@ -9,7 +9,7 @@ module Plumb
   class ArrayClass
     include Composable
 
-    attr_reader :element_type, :children
+    attr_reader :children
 
     def initialize(element_type: Types::Any)
       @element_type = Composable.wrap(element_type)
@@ -52,6 +52,8 @@ module Plumb
     end
 
     private
+
+    attr_reader :element_type
 
     def _inspect
       %(Array[#{element_type}])

--- a/lib/plumb/array_class.rb
+++ b/lib/plumb/array_class.rb
@@ -9,10 +9,11 @@ module Plumb
   class ArrayClass
     include Composable
 
-    attr_reader :element_type
+    attr_reader :element_type, :children
 
     def initialize(element_type: Types::Any)
       @element_type = Composable.wrap(element_type)
+      @children = [@element_type].freeze
 
       freeze
     end

--- a/lib/plumb/build.rb
+++ b/lib/plumb/build.rb
@@ -6,11 +6,12 @@ module Plumb
   class Build
     include Composable
 
-    attr_reader :type
+    attr_reader :children
 
     def initialize(type, factory_method: :new, &block)
       @type = type
       @block = block || ->(value) { type.send(factory_method, value) }
+      @children = [type].freeze
       freeze
     end
 

--- a/lib/plumb/composable.rb
+++ b/lib/plumb/composable.rb
@@ -193,6 +193,8 @@ module Plumb
       end
     end
 
+    def children = BLANK_ARRAY
+
     def build(cns, factory_method = :new, &block)
       self >> Build.new(cns, factory_method:, &block)
     end

--- a/lib/plumb/hash_map.rb
+++ b/lib/plumb/hash_map.rb
@@ -6,7 +6,7 @@ module Plumb
   class HashMap
     include Composable
 
-    attr_reader :key_type, :value_type, :children
+    attr_reader :children
 
     def initialize(key_type, value_type)
       @key_type = key_type
@@ -36,7 +36,7 @@ module Plumb
     end
 
     def filtered
-      FilteredHashMap.new(key_type, value_type)
+      FilteredHashMap.new(@key_type, @value_type)
     end
 
     private def _inspect = "HashMap[#{@key_type.inspect}, #{@value_type.inspect}]"
@@ -44,7 +44,7 @@ module Plumb
     class FilteredHashMap
       include Composable
 
-      attr_reader :key_type, :value_type, :children
+      attr_reader :children
 
       def initialize(key_type, value_type)
         @key_type = key_type

--- a/lib/plumb/hash_map.rb
+++ b/lib/plumb/hash_map.rb
@@ -6,11 +6,12 @@ module Plumb
   class HashMap
     include Composable
 
-    attr_reader :key_type, :value_type
+    attr_reader :key_type, :value_type, :children
 
     def initialize(key_type, value_type)
       @key_type = key_type
       @value_type = value_type
+      @children = [key_type, value_type].freeze
       freeze
     end
 
@@ -43,11 +44,12 @@ module Plumb
     class FilteredHashMap
       include Composable
 
-      attr_reader :key_type, :value_type
+      attr_reader :key_type, :value_type, :children
 
       def initialize(key_type, value_type)
         @key_type = key_type
         @value_type = value_type
+        @children = [key_type, value_type].freeze
         freeze
       end
 

--- a/lib/plumb/match_class.rb
+++ b/lib/plumb/match_class.rb
@@ -6,7 +6,7 @@ module Plumb
   class MatchClass
     include Composable
 
-    attr_reader :matcher
+    attr_reader :matcher, :children
 
     def initialize(matcher = Undefined, error: nil, label: nil)
       raise TypeError 'matcher must respond to #===' unless matcher.respond_to?(:===)
@@ -14,6 +14,7 @@ module Plumb
       @matcher = matcher
       @error = error.nil? ? build_error(matcher) : (error % matcher)
       @label = matcher.is_a?(Class) ? matcher.inspect : "Match(#{label || @matcher.inspect})"
+      @children = [matcher].freeze
       freeze
     end
 

--- a/lib/plumb/match_class.rb
+++ b/lib/plumb/match_class.rb
@@ -6,7 +6,7 @@ module Plumb
   class MatchClass
     include Composable
 
-    attr_reader :matcher, :children
+    attr_reader :children
 
     def initialize(matcher = Undefined, error: nil, label: nil)
       raise TypeError 'matcher must respond to #===' unless matcher.respond_to?(:===)

--- a/lib/plumb/metadata_visitor.rb
+++ b/lib/plumb/metadata_visitor.rb
@@ -10,23 +10,14 @@ module Plumb
       new.visit(node)
     end
 
-    def on_missing_handler(node, props, method_name)
+    def on_missing_handler(node, props, _method_name)
       return props.merge(type: node) if node.instance_of?(Class)
 
-      puts "Missing handler for #{node.inspect} with props #{node.inspect} and method_name :#{method_name}"
-      props
-    end
+      return props unless node.respond_to?(:children)
 
-    on(:undefined) do |_node, props|
-      props
-    end
-
-    on(:any) do |_node, props|
-      props
-    end
-
-    on(:pipeline) do |node, props|
-      visit(node.type, props)
+      node.children.reduce(props) do |acc, child|
+        visit(child, acc)
+      end
     end
 
     on(:step) do |node, props|
@@ -42,17 +33,12 @@ module Plumb
       props.merge(match: node, type:)
     end
 
-    on(:match) do |node, props|
-      visit(node.matcher, props)
-    end
-
     on(:hash) do |_node, props|
       props.merge(type: Hash)
     end
 
     on(:and) do |node, props|
-      left = visit(node.left)
-      right = visit(node.right)
+      left, right = node.children.map { |child| visit(child) }
       type = right[:type] || left[:type]
       props = props.merge(left).merge(right)
       props = props.merge(type:) if type
@@ -60,20 +46,12 @@ module Plumb
     end
 
     on(:or) do |node, props|
-      child_metas = [visit(node.left), visit(node.right)]
+      child_metas = node.children.map { |child| visit(child) }
       types = child_metas.map { |child| child[:type] }.flatten.compact
       types = types.first if types.size == 1
       child_metas.reduce(props) do |acc, child|
         acc.merge(child)
       end.merge(type: types)
-    end
-
-    on(:value) do |node, props|
-      visit(node.value, props)
-    end
-
-    on(:transform) do |node, props|
-      props.merge(type: node.target_type)
     end
 
     on(:static) do |node, props|
@@ -82,15 +60,9 @@ module Plumb
     end
 
     on(:policy) do |node, props|
-      props = visit(node.step, props)
+      props = visit(node.children[0], props)
       props = props.merge(node.policy_name => node.arg) unless node.arg == Plumb::Undefined
       props
-    end
-
-    on(:rules) do |node, props|
-      node.rules.reduce(props) do |acc, rule|
-        acc.merge(rule.name => rule.arg_value)
-      end
     end
 
     on(:boolean) do |_node, props|
@@ -103,10 +75,6 @@ module Plumb
 
     on(:hash_map) do |_node, props|
       props.merge(type: Hash)
-    end
-
-    on(:build) do |node, props|
-      visit(node.type, props)
     end
 
     on(:array) do |_node, props|

--- a/lib/plumb/metadata_visitor.rb
+++ b/lib/plumb/metadata_visitor.rb
@@ -55,8 +55,9 @@ module Plumb
     end
 
     on(:static) do |node, props|
-      type = node.value.is_a?(Class) ? node.value : node.value.class
-      props.merge(static: node.value, type:)
+      value = node.children[0]
+      type = value.is_a?(Class) ? value : value.class
+      props.merge(static: value, type:)
     end
 
     on(:policy) do |node, props|

--- a/lib/plumb/not.rb
+++ b/lib/plumb/not.rb
@@ -6,7 +6,7 @@ module Plumb
   class Not
     include Composable
 
-    attr_reader :step, :children
+    attr_reader :children
 
     def initialize(step, errors: nil)
       @step = step

--- a/lib/plumb/not.rb
+++ b/lib/plumb/not.rb
@@ -6,11 +6,12 @@ module Plumb
   class Not
     include Composable
 
-    attr_reader :step
+    attr_reader :step, :children
 
     def initialize(step, errors: nil)
       @step = step
       @errors = errors
+      @children = [step].freeze
       freeze
     end
 

--- a/lib/plumb/or.rb
+++ b/lib/plumb/or.rb
@@ -6,7 +6,7 @@ module Plumb
   class Or
     include Composable
 
-    attr_reader :left, :right, :children
+    attr_reader :children
 
     def initialize(left, right)
       @left = left

--- a/lib/plumb/or.rb
+++ b/lib/plumb/or.rb
@@ -6,11 +6,12 @@ module Plumb
   class Or
     include Composable
 
-    attr_reader :left, :right
+    attr_reader :left, :right, :children
 
     def initialize(left, right)
       @left = left
       @right = right
+      @children = [left, right].freeze
       freeze
     end
 

--- a/lib/plumb/pipeline.rb
+++ b/lib/plumb/pipeline.rb
@@ -19,10 +19,11 @@ module Plumb
       end
     end
 
-    attr_reader :type
+    attr_reader :type, :children
 
     def initialize(type = Types::Any, &setup)
       @type = type
+      @children = [type].freeze
       @around_blocks = []
       return unless block_given?
 
@@ -38,7 +39,7 @@ module Plumb
       callable ||= block
       unless is_a_step?(callable)
         raise ArgumentError,
-          "#step expects an interface #call(Result) Result, but got #{callable.inspect}"
+              "#step expects an interface #call(Result) Result, but got #{callable.inspect}"
       end
 
       callable = @around_blocks.reduce(callable) { |cl, bl| AroundStep.new(cl, bl) } if @around_blocks.any?

--- a/lib/plumb/pipeline.rb
+++ b/lib/plumb/pipeline.rb
@@ -19,7 +19,7 @@ module Plumb
       end
     end
 
-    attr_reader :type, :children
+    attr_reader :children
 
     def initialize(type = Types::Any, &setup)
       @type = type

--- a/lib/plumb/policy.rb
+++ b/lib/plumb/policy.rb
@@ -9,7 +9,7 @@ module Plumb
   class Policy
     include Composable
 
-    attr_reader :policy_name, :arg, :step, :children
+    attr_reader :policy_name, :arg, :children
 
     # @param policy_name [Symbol]
     # @param arg [Object, nil] the argument to the policy, if any.

--- a/lib/plumb/policy.rb
+++ b/lib/plumb/policy.rb
@@ -9,7 +9,7 @@ module Plumb
   class Policy
     include Composable
 
-    attr_reader :policy_name, :arg, :step
+    attr_reader :policy_name, :arg, :step, :children
 
     # @param policy_name [Symbol]
     # @param arg [Object, nil] the argument to the policy, if any.
@@ -18,6 +18,7 @@ module Plumb
       @policy_name = policy_name
       @arg = arg
       @step = step
+      @children = [step].freeze
       freeze
     end
 

--- a/lib/plumb/static_class.rb
+++ b/lib/plumb/static_class.rb
@@ -6,7 +6,7 @@ module Plumb
   class StaticClass
     include Composable
 
-    attr_reader :value, :children
+    attr_reader :children
 
     def initialize(value = Undefined)
       raise ArgumentError, 'value must be frozen' unless value.frozen?

--- a/lib/plumb/static_class.rb
+++ b/lib/plumb/static_class.rb
@@ -6,12 +6,13 @@ module Plumb
   class StaticClass
     include Composable
 
-    attr_reader :value
+    attr_reader :value, :children
 
     def initialize(value = Undefined)
       raise ArgumentError, 'value must be frozen' unless value.frozen?
 
       @value = value
+      @children = [value].freeze
       freeze
     end
 

--- a/lib/plumb/stream_class.rb
+++ b/lib/plumb/stream_class.rb
@@ -17,11 +17,12 @@ module Plumb
   class StreamClass
     include Composable
 
-    attr_reader :element_type
+    attr_reader :element_type, :children
 
     # @option element_type [Composable] the type of the elements in the stream
     def initialize(element_type: Types::Any)
       @element_type = Composable.wrap(element_type)
+      @children = [@element_type].freeze
       freeze
     end
 

--- a/lib/plumb/stream_class.rb
+++ b/lib/plumb/stream_class.rb
@@ -17,7 +17,7 @@ module Plumb
   class StreamClass
     include Composable
 
-    attr_reader :element_type, :children
+    attr_reader :children
 
     # @option element_type [Composable] the type of the elements in the stream
     def initialize(element_type: Types::Any)
@@ -40,7 +40,7 @@ module Plumb
 
       enum = Enumerator.new do |y|
         result.value.each do |e|
-          y << element_type.resolve(e)
+          y << @element_type.resolve(e)
         end
       end
 

--- a/lib/plumb/tagged_hash.rb
+++ b/lib/plumb/tagged_hash.rb
@@ -6,12 +6,13 @@ module Plumb
   class TaggedHash
     include Composable
 
-    attr_reader :key, :types
+    attr_reader :key, :types, :children
 
     def initialize(hash_type, key, types)
       @hash_type = hash_type
       @key = Key.wrap(key)
       @types = types
+      @children = types
 
       raise ArgumentError, 'all types must be HashClass' if @types.size.zero? || @types.any? do |t|
         !t.is_a?(HashClass)

--- a/lib/plumb/tagged_hash.rb
+++ b/lib/plumb/tagged_hash.rb
@@ -6,25 +6,24 @@ module Plumb
   class TaggedHash
     include Composable
 
-    attr_reader :key, :types, :children
+    attr_reader :key, :children
 
-    def initialize(hash_type, key, types)
+    def initialize(hash_type, key, children)
       @hash_type = hash_type
       @key = Key.wrap(key)
-      @types = types
-      @children = types
+      @children = children
 
-      raise ArgumentError, 'all types must be HashClass' if @types.size.zero? || @types.any? do |t|
+      raise ArgumentError, 'all types must be HashClass' if @children.size.zero? || @children.any? do |t|
         !t.is_a?(HashClass)
       end
-      raise ArgumentError, "all types must define key #{@key}" unless @types.all? { |t| !!t.at_key(@key) }
+      raise ArgumentError, "all types must define key #{@key}" unless @children.all? { |t| !!t.at_key(@key) }
 
       # types are assumed to have literal values for the index field :key
-      @index = @types.each.with_object({}) do |t, memo|
+      @index = @children.each.with_object({}) do |t, memo|
         key_type = t.at_key(@key)
         raise TypeError, "key type at :#{@key} #{key_type} must be a Match type" unless key_type.is_a?(MatchClass)
 
-        memo[key_type.matcher] = t
+        memo[key_type.children[0]] = t
       end
 
       freeze
@@ -42,6 +41,6 @@ module Plumb
 
     private
 
-    def _inspect = "TaggedHash[#{@key.inspect}, #{@types.map(&:inspect).join(', ')}]"
+    def _inspect = "TaggedHash[#{@key.inspect}, #{@children.map(&:inspect).join(', ')}]"
   end
 end

--- a/lib/plumb/transform.rb
+++ b/lib/plumb/transform.rb
@@ -6,7 +6,7 @@ module Plumb
   class Transform
     include Composable
 
-    attr_reader :target_type, :children
+    attr_reader :children
 
     def initialize(target_type, callable)
       @target_type = target_type

--- a/lib/plumb/transform.rb
+++ b/lib/plumb/transform.rb
@@ -6,11 +6,12 @@ module Plumb
   class Transform
     include Composable
 
-    attr_reader :target_type
+    attr_reader :target_type, :children
 
     def initialize(target_type, callable)
       @target_type = target_type
       @callable = callable || Plumb::NOOP
+      @children = [target_type].freeze
       freeze
     end
 

--- a/lib/plumb/tuple_class.rb
+++ b/lib/plumb/tuple_class.rb
@@ -6,11 +6,10 @@ module Plumb
   class TupleClass
     include Composable
 
-    attr_reader :types, :children
+    attr_reader :children
 
-    def initialize(*types)
-      @types = types.map { |t| Composable.wrap(t) }.freeze
-      @children = @types
+    def initialize(*children)
+      @children = children.map { |t| Composable.wrap(t) }.freeze
       freeze
     end
 
@@ -22,10 +21,10 @@ module Plumb
 
     def call(result)
       return result.invalid(errors: 'must be an Array') unless result.value.is_a?(::Array)
-      return result.invalid(errors: 'must have the same size') unless result.value.size == @types.size
+      return result.invalid(errors: 'must have the same size') unless result.value.size == @children.size
 
       errors = {}
-      values = @types.map.with_index do |type, idx|
+      values = @children.map.with_index do |type, idx|
         val = result.value[idx]
         r = type.resolve(val)
         errors[idx] = ["expected #{type.inspect}, got #{val.inspect}", r.errors].flatten unless r.valid?
@@ -40,7 +39,7 @@ module Plumb
     private
 
     def _inspect
-      "Tuple[#{@types.map(&:inspect).join(', ')}]"
+      "Tuple[#{@children.map(&:inspect).join(', ')}]"
     end
   end
 end

--- a/lib/plumb/tuple_class.rb
+++ b/lib/plumb/tuple_class.rb
@@ -6,10 +6,11 @@ module Plumb
   class TupleClass
     include Composable
 
-    attr_reader :types
+    attr_reader :types, :children
 
     def initialize(*types)
-      @types = types.map { |t| Composable.wrap(t) }
+      @types = types.map { |t| Composable.wrap(t) }.freeze
+      @children = @types
       freeze
     end
 

--- a/lib/plumb/value_class.rb
+++ b/lib/plumb/value_class.rb
@@ -6,7 +6,7 @@ module Plumb
   class ValueClass
     include Composable
 
-    attr_reader :value, :children
+    attr_reader :children
 
     def initialize(value = Undefined)
       @value = value

--- a/lib/plumb/value_class.rb
+++ b/lib/plumb/value_class.rb
@@ -6,10 +6,11 @@ module Plumb
   class ValueClass
     include Composable
 
-    attr_reader :value
+    attr_reader :value, :children
 
     def initialize(value = Undefined)
       @value = value
+      @children = [value].freeze
       freeze
     end
 

--- a/lib/plumb/visitor_handlers.rb
+++ b/lib/plumb/visitor_handlers.rb
@@ -39,5 +39,11 @@ module Plumb
     def on_missing_handler(node, _props, method_name)
       raise "No handler for #{node.inspect} with :#{method_name}"
     end
+
+    def visit_children(node, props = BLANK_HASH)
+      node.children.reduce(props) do |acc, child|
+        visit(child, acc)
+      end
+    end
   end
 end


### PR DESCRIPTION
Remove class-specific public methods from step classes, such as `#left, #right, #value, #matcher`, etc.
Instead, make all steps expose `#children() => Array<Composable>`.

So that I can build generic visitors that walk a graph of composable, and their children.