### PR TITLE
Allow `Types::Data[HashClass]`

### DIFF
--- a/README.md
+++ b/README.md
@@ -904,6 +904,13 @@ person.valid? # false
 person.errors[:age] # 'must be an integer'
 ```
 
+Data structs can also be defined from `Types::Hash` instances.
+
+```ruby
+PersonHash = Types::Hash[name: String, age?: Integer]
+PersonStruct = Types::Data[PersonHash]
+```
+
 #### `#with`
 
 Note that these instances cannot be mutated (there's no attribute setters), but they can be copied with partial attributes with `#with`

--- a/lib/plumb/attributes.rb
+++ b/lib/plumb/attributes.rb
@@ -188,6 +188,7 @@ module Plumb
 
       # Person = Data[:name => String, :age => Integer, title?: String]
       def [](type_specs)
+        type_specs = type_specs._schema if type_specs.is_a?(Plumb::HashClass)
         klass = Class.new(self)
         type_specs.each do |key, type|
           klass.attribute(key, type)

--- a/spec/data_spec.rb
+++ b/spec/data_spec.rb
@@ -246,4 +246,12 @@ RSpec.describe Types::Data do
       expect(type.metadata[:type]).to eq([Types::StaffMember, Types::User])
     end
   end
+
+  specify 'defining from Types::Hash' do
+    hash = Types::Hash[name: String, age?: Integer]
+    data = Types::Data[hash]
+    instance = data.new(name: 'Joe')
+    expect(instance.name).to eq('Joe')
+    expect(instance.age).to be(nil)
+  end
 end


### PR DESCRIPTION
Allow defining data structs from `Types::Hash` instances.

```ruby
PersonHash = Types::Hash[name: String, age?: Integer]
PersonStruct = Types::Data[PersonHash]

person = PersonStruct.new(name: 'Joe', age: 40)
```