### PR TITLE
URI types

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,6 +236,9 @@ You can see more use cases in [the examples directory](https://github.com/ismasa
 * `Types::Email`
 * `Types::Date`
 * `Types::Time`
+* `Types::URI::Generic`
+* `Types::URI::HTTP`
+* `Types::URI::File`
 * `Types::Lax::Integer`
 * `Types::Lax::String`
 * `Types::Lax::Symbol`
@@ -245,6 +248,9 @@ You can see more use cases in [the examples directory](https://github.com/ismasa
 * `Types::Forms::False`
 * `Types::Forms::Date`
 * `Types::Forms::Time`
+* `Types::Forms::URI::Generic`
+* `Types::Forms::URI::HTTP`
+* `Types::Forms::URI::File`
 
 TODO: datetime, others.
 

--- a/examples/concurrent_downloads.rb
+++ b/examples/concurrent_downloads.rb
@@ -12,9 +12,6 @@ require 'digest/md5'
 module Types
   include Plumb::Types
 
-  # Turn a string into an URI
-  URL = String[/^https?:/].build(::URI, :parse)
-
   # a Struct to hold image data
   Image = ::Data.define(:url, :io)
 
@@ -24,7 +21,7 @@ module Types
   # required by all Plumb steps.
   # URI => Image
   Download = Plumb::Step.new do |result|
-    io = URI.open(result.value)
+    io = ::URI.open(result.value)
     result.valid(Image.new(result.value.to_s, io))
   end
 
@@ -81,7 +78,7 @@ cache = Types::Cache.new('./examples/data/downloads')
 # 1). Take a valid URL string.
 # 2). Attempt reading the file from the cache. Return that if it exists.
 # 3). Otherwise, download the file from the internet and write it to the cache.
-IdempotentDownload = Types::URL >> (cache.read | (Types::Download >> cache.write))
+IdempotentDownload = Types::Forms::URI::HTTP >> (cache.read | (Types::Download >> cache.write))
 
 # An array of downloadable images,
 # marked as concurrent so that all IO operations are run in threads.

--- a/lib/plumb/json_schema_visitor.rb
+++ b/lib/plumb/json_schema_visitor.rb
@@ -255,6 +255,18 @@ module Plumb
       props.merge(TYPE => 'string', FORMAT => 'date')
     end
 
+    on(::URI::Generic) do |_node, props|
+      props.merge(TYPE => 'string', FORMAT => 'uri')
+    end
+
+    on(::URI::HTTP) do |_node, props|
+      props.merge(TYPE => 'string', FORMAT => 'uri')
+    end
+
+    on(::URI::File) do |_node, props|
+      props.merge(TYPE => 'string', FORMAT => 'uri')
+    end
+
     on(::Hash) do |_node, props|
       props.merge(TYPE => 'object')
     end

--- a/lib/plumb/types.rb
+++ b/lib/plumb/types.rb
@@ -168,6 +168,12 @@ module Plumb
       V4 = String[/\A[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\z/i].as_node(:uuid)
     end
 
+    module URI
+      Generic = Any[::URI::Generic]
+      HTTP = Any[::URI::HTTP]
+      File = Any[::URI::File]
+    end
+
     class Data
       extend Composable
       include Plumb::Attributes
@@ -217,6 +223,15 @@ module Plumb
       # via Date.parse
       Date = Date | (String >> Any.build(::Date, :parse).policy(:rescue, ::Date::Error))
       Time = Time | (String >> Any.build(::Time, :parse).policy(:rescue, ::ArgumentError))
+
+      # Turn strings into different URI types
+      module URI
+        # URI.parse is very permisive - a blank string is valid.
+        # We want to ensure that a generic URI at least starts with a scheme as per RFC 3986
+        Generic = Types::URI::Generic | (String[/^([a-z][a-z0-9+\-.]*)/].build(::URI, :parse))
+        HTTP = Generic[::URI::HTTP]
+        File = Generic[::URI::File]
+      end
     end
   end
 end

--- a/spec/json_schema_visitor_spec.rb
+++ b/spec/json_schema_visitor_spec.rb
@@ -135,6 +135,11 @@ RSpec.describe Plumb::JSONSchemaVisitor do
     expect(described_class.visit(type)).to eq('type' => 'string', 'format' => 'date-time')
   end
 
+  specify 'Types::URI' do
+    type = Types::Any[URI::Generic]
+    expect(described_class.visit(type)).to eq('type' => 'string', 'format' => 'uri')
+  end
+
   specify 'Not' do
     type = Types::Decimal.not
     expect(described_class.visit(type)).to eq('not' => { 'type' => 'number' })

--- a/spec/types_spec.rb
+++ b/spec/types_spec.rb
@@ -468,6 +468,54 @@ RSpec.describe Plumb::Types do
       assert_result(Types::Email.resolve('joe.bloggs+oneemail'), 'joe.bloggs+oneemail', false)
     end
 
+    describe 'URI' do
+      let(:http_str) { 'http://foo.bar' }
+      let(:file_str) { 'file:///foo/bar' }
+      let(:http_uri) { URI.parse(http_str) }
+      let(:file_uri) { URI.parse(file_str) }
+
+      specify Types::URI::Generic do
+        assert_result(Types::URI::Generic.resolve(http_uri), http_uri, true)
+        assert_result(Types::URI::Generic.resolve(file_uri), file_uri, true)
+        assert_result(Types::URI::Generic.resolve(19), 19, false)
+      end
+
+      specify Types::URI::HTTP do
+        assert_result(Types::URI::HTTP.resolve(http_uri), http_uri, true)
+        assert_result(Types::URI::HTTP.resolve(file_uri), file_uri, false)
+        assert_result(Types::URI::HTTP.resolve(19), 19, false)
+      end
+
+      specify Types::URI::File do
+        assert_result(Types::URI::File.resolve(http_uri), http_uri, false)
+        assert_result(Types::URI::File.resolve(file_uri), file_uri, true)
+        assert_result(Types::URI::File.resolve(19), 19, false)
+      end
+
+      describe 'Forms::URI' do
+        specify Types::Forms::URI::Generic do
+          assert_result(Types::Forms::URI::Generic.resolve(http_uri), http_uri, true)
+          assert_result(Types::Forms::URI::Generic.resolve(file_uri), file_uri, true)
+          assert_result(Types::Forms::URI::Generic.resolve(http_str), http_uri, true)
+          assert_result(Types::Forms::URI::Generic.resolve(file_str), file_uri, true)
+        end
+
+        specify Types::Forms::URI::HTTP do
+          assert_result(Types::Forms::URI::HTTP.resolve(http_uri), http_uri, true)
+          assert_result(Types::Forms::URI::HTTP.resolve(file_uri), file_uri, false)
+          assert_result(Types::Forms::URI::HTTP.resolve(http_str), http_uri, true)
+          assert_result(Types::Forms::URI::HTTP.resolve(file_str), file_uri, false)
+        end
+
+        specify Types::Forms::URI::File do
+          assert_result(Types::Forms::URI::File.resolve(http_uri), http_uri, false)
+          assert_result(Types::Forms::URI::File.resolve(file_uri), file_uri, true)
+          assert_result(Types::Forms::URI::File.resolve(http_str), http_uri, false)
+          assert_result(Types::Forms::URI::File.resolve(file_str), file_uri, true)
+        end
+      end
+    end
+
     specify Types::Date do
       date = Date.new(2024, 1, 2)
       assert_result(Types::Date.resolve(date), date, true)


### PR DESCRIPTION
Built-in URI types, based on `URI.parse`.

```ruby
# Expect any URI type
Types::URI::Generic.resolve(URI.parse('http://foo.bar)') # => valid URI::HTTP

# Expect any URI::HTTP
Types::URI::HTTP.resolve(URI.parse('http://foo.bar')) # => URI::HTTP
Types::URI::HTTP.resolve(URI.parse('file://foo/bar')) # INVALID

# Expect any URI::File
Types::URI::File.resolve(URI.parse('file:///foo/bar')) # => URI::File
Types::URI::File.resolve(URI.parse('http:///foo.bar')) # INVALID
```

The variants under `Types::Forms` accept strings

```ruby
Types::URI::HTTP.resolve('http://foo.bar') # => URI::HTTP
Types::URI::File.resolve('file:///foo/bar') # => URI::HTTP
```
