### PR TITLE
Shorthand array attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -1061,7 +1061,25 @@ Note that this does NOT work with union'd or piped structs.
 attribute :company, Company | Person do
 ```
 
+#### Shorthand array syntax
+
+```ruby
+attribute :things, [] # Same as attribute :things, Types::Array
+attribute :numbers, [Integer] # Same as attribute :numbers, Types::Array[Integer]
+attribute :people, [Person] # same as attribute :people, Types::Array[Person]
+attribute :friends, [Person] do # same as attribute :friends, Types::Array[Person] do...
+  attribute :phone_number, Integer
+end
+```
+
+Note that, if you want to match an attribute value against a literal array, you need to use `#value`
+
+```ruby
+attribute :one_two_three, Types::Array.value[[1, 2, 3]])
+```
+
 #### Optional Attributes
+
 Using `attribute?` allows for optional attributes. If the attribute is not present, these attribute values will be `nil`
 
 ```ruby

--- a/lib/plumb/attributes.rb
+++ b/lib/plumb/attributes.rb
@@ -205,11 +205,20 @@ module Plumb
       # attribute(:name, String)
       # attribute(:friends, Types::Array) { attribute(:name, String) }
       # attribute(:friends, Types::Array) # same as Types::Array[Types::Any]
+      # attribute(:friends, []) # same as Types::Array[Types::Any]
       # attribute(:friends, Types::Array[Person])
+      # attribute(:friends, [Person])
       #
       def attribute(name, type = Types::Any, &block)
         key = Key.wrap(name)
         name = key.to_sym
+        if type.is_a?(::Array)
+          raise ArgumentError, 'Array type must have a single element' if type.size > 1
+
+          element = type.any? ? type.first : Types::Any
+          type = Types::Array[element]
+        end
+
         type = Composable.wrap(type)
         if block_given? # :foo, Array[Data] or :foo, Struct
           type = __plumb_struct_class__ if type == Types::Any

--- a/lib/plumb/attributes.rb
+++ b/lib/plumb/attributes.rb
@@ -212,12 +212,6 @@ module Plumb
       def attribute(name, type = Types::Any, &block)
         key = Key.wrap(name)
         name = key.to_sym
-        if type.is_a?(::Array)
-          raise ArgumentError, 'Array type must have a single element' if type.size > 1
-
-          element = type.any? ? type.first : Types::Any
-          type = Types::Array[element]
-        end
 
         type = Composable.wrap(type)
         if block_given? # :foo, Array[Data] or :foo, Struct

--- a/lib/plumb/attributes.rb
+++ b/lib/plumb/attributes.rb
@@ -212,8 +212,8 @@ module Plumb
       def attribute(name, type = Types::Any, &block)
         key = Key.wrap(name)
         name = key.to_sym
-
         type = Composable.wrap(type)
+
         if block_given? # :foo, Array[Data] or :foo, Struct
           type = __plumb_struct_class__ if type == Types::Any
           type = Plumb.decorate(type) do |node|

--- a/spec/data_spec.rb
+++ b/spec/data_spec.rb
@@ -173,6 +173,32 @@ RSpec.describe Types::Data do
     expect(office.staff.first.errors[:age]).not_to be_empty
   end
 
+  specify 'shorthand typed array syntax' do
+    klass = Class.new(Types::Data) do
+      attribute :typed_array, [Integer]
+      attribute :untyped_array, []
+      attribute :data_array, [] do
+        attribute :name, String
+      end
+    end
+
+    thing = klass.new(typed_array: [1, 2, 3], untyped_array: [1, 'hello'], data_array: [{ name: 'foo' }])
+    expect(thing.typed_array).to eq([1, 2, 3])
+    expect(thing.untyped_array).to eq([1, 'hello'])
+    expect(thing.data_array.map(&:name)).to eq(['foo'])
+    expect(thing.valid?).to be(true)
+    thing = klass.new(typed_array: [1, 2, '3'])
+    expect(thing.valid?).to be(false)
+  end
+
+  specify 'invalid shorthard array with multiple elements' do
+    expect do
+      klass = Class.new(Types::Data) do
+        attribute :typed_array, [Integer, String]
+      end
+    end.to raise_error(ArgumentError, 'Array type must have a single element')
+  end
+
   specify 'invalid' do
     user = Types::User.new(
       name: 'Jane',

--- a/spec/data_spec.rb
+++ b/spec/data_spec.rb
@@ -196,7 +196,7 @@ RSpec.describe Types::Data do
       klass = Class.new(Types::Data) do
         attribute :typed_array, [Integer, String]
       end
-    end.to raise_error(ArgumentError, 'Array type must have a single element')
+    end.to raise_error(ArgumentError)
   end
 
   specify 'invalid' do


### PR DESCRIPTION
#### Shorthand array syntax for data attributes

Use a literal array to define array attributes in data structs.
This actually works already via changes to `Composable.wrap(Object)`, but I'm documenting it here.

```ruby
class Foo < Types::Data
  attribute :things, [] # Same as attribute :things, Types::Array
  attribute :numbers, [Integer] # Same as attribute :numbers, Types::Array[Integer]
  attribute :people, [Person] # same as attribute :people, Types::Array[Person]
  attribute :friends, [Person] do # same as attribute :friends, Types::Array[Person] do...
    attribute :phone_number, Integer
  end
end
```

Note that, if you want to match an attribute value against a literal array, you need to use `#value`

```ruby
attribute :one_two_three, Types::Array.value[[1, 2, 3]])
```
