### PR TITLE
Composable#static

### DIFF
--- a/README.md
+++ b/README.md
@@ -484,7 +484,22 @@ Note that the value must be of the same type as the starting step's target type.
 Types::Integer.static('nope') # raises ArgumentError
 ```
 
-This usage is the same as using `Types::Static['hello']`directly.
+This usage is similar as using `Types::Static['hello']`directly.
+
+This helper is shorthand for the following composition:
+
+```ruby
+Types::Static[value] >> step
+```
+
+This means that validations and coercions in the original step are still applied to the static value.
+
+```ruby
+ten = Types::Integer[100..].static(10)
+ten.parse # => Plumb::ParseError "Must be within 100..."
+```
+
+So, normally you'd only use this attached to primitive types without further processing (but your use case may vary).
 
 ##### Block usage
 

--- a/README.md
+++ b/README.md
@@ -455,6 +455,54 @@ All scalar types support this:
 ten = Types::Integer.value(10)
 ```
 
+#### `#static`
+
+A type that always returns a valid, static value, regardless of input.
+
+```ruby
+ten = Types::Integer.static(10)
+ten.parse(10) # => 10
+ten.parse(100) # => 10
+ten.parse('hello') # => 10
+ten.parse() # => 10
+ten.metadata[:type] # => Integer
+```
+
+Useful for data structures where some fields shouldn't change. Example:
+
+```ruby
+CreateUserEvent = Types::Hash[
+  type: Types::String.static('CreateUser'),
+  name: String,
+  age: Integer
+]
+```
+
+Note that the value must be of the same type as the starting step's target type.
+
+```ruby
+Types::Integer.static('nope') # raises ArgumentError
+```
+
+This usage is the same as using `Types::Static['hello']`directly.
+
+##### Block usage
+
+Passing a proc will evaluate the proc on every invocation. Use this for generated values.
+
+```ruby
+random_number = Types::Numeric.static { rand }
+random_number.parse # 0.32332
+random_number.parse('foo') # 0.54322 etc
+```
+
+Note that in this mode, the type of generated value must match the initial step's type, validated at invocation.
+
+```ruby
+random_number = Types::String.static { rand } # this won't raise an error here
+random_number.parse # raises Plumb::ParseError because `rand` is not a String
+```
+
 #### `#metadata`
 
 Add metadata to a type

--- a/lib/plumb/composable.rb
+++ b/lib/plumb/composable.rb
@@ -341,6 +341,35 @@ module Plumb
       self >> Build.new(cns, factory_method:, &block)
     end
 
+    # Always return a static value, regarless of the input.
+    # When given a block, the block will be called to get the value, on every invocation.
+    # @example
+    #   type = Types::Integer.static(10)
+    #   type.parse(10) # => 10
+    #   type.parse(100) # => 10
+    #   type.parse # => 10
+    #
+    #  # with block
+    #  type = Types::Integer.static { Time.now.to_i }
+    # @param value [Object, Undefined]
+    # @param block [Proc]
+    # @return [And]
+    def static(value = Undefined, &block)
+      if value == Undefined
+        raise ArgumentError, 'expected a value or block' unless block_given?
+
+        Step.new(->(r) { r.valid(block.call) }, 'static') >> self
+      else
+        my_type = Array(metadata[:type]).first
+        unless value.instance_of?(my_type)
+          raise ArgumentError,
+                "can't set a static #{value.class} value for a #{my_type} step"
+        end
+
+        StaticClass.new(value) >> self
+      end
+    end
+
     # Build a Plumb::Pipeline with this object as the starting step.
     # @example
     #   pipe = Types::Data[name: String].pipeline do |pl|

--- a/spec/types_spec.rb
+++ b/spec/types_spec.rb
@@ -321,6 +321,33 @@ RSpec.describe Plumb::Types do
     expect(with_symbol.metadata[:type]).to eq(custom)
   end
 
+  describe '#static' do
+    it 'returns a static value if argument given' do
+      type = Types::Integer.static(10)
+      expect(type.parse(10)).to eq(10)
+      expect(type.parse(11)).to eq(10)
+      expect(type.parse('foo')).to eq(10)
+      expect(type.parse).to eq(10)
+      expect(type.metadata[:type]).to eq(Integer)
+    end
+
+    it 'does not allow inconsistent types' do
+      expect do
+        Types::Integer.static('nope')
+      end.to raise_error(ArgumentError)
+    end
+
+    it 'lazily evaluates a block, if given' do
+      count = 0
+      type = Types::Integer.static { count += 1 }
+      expect(type.parse(10)).to eq(1)
+      expect(type.parse(100)).to eq(2)
+      expect(type.parse).to eq(3)
+      expect(type.parse('foo')).to eq(4)
+      expect(type.metadata[:type]).to eq(Integer)
+    end
+  end
+
   describe '#policy' do
     specify ':size' do
       assert_result(Types::Array.policy(size: 2).resolve([1]), [1], false)


### PR DESCRIPTION
#### `#static`

A type that always returns a valid, static value, regardless of input.

```ruby
ten = Types::Integer.static(10)
ten.parse(10) # => 10
ten.parse(100) # => 10
ten.parse('hello') # => 10
ten.parse() # => 10
ten.metadata[:type] # => Integer
```

Useful for data structures where some fields shouldn't change. Example:

```ruby
CreateUserEvent = Types::Hash[
  type: Types::String.static('CreateUser'),
  name: String,
  age: Integer
]
```

Note that the value must be of the same type as the starting step's target type.

```ruby
Types::Integer.static('nope') # raises ArgumentError
```

This usage is the same as using `Types::Static['hello']`directly.

##### Block usage

Passing a proc will evaluate the proc on every invocation. Use this for generated values.

```ruby
random_number = Types::Numeric.static { rand }
random_number.parse # 0.32332
random_number.parse('foo') # 0.54322 etc
```

Note that in this mode, the type of generated value must match the initial step's type, validated at invocation.

```ruby
random_number = Types::String.static { rand } # this won't raise an error here
random_number.parse # raises Plumb::ParseError because `rand` is not a String
```
