### PR TITLE
Data writeable attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1216,6 +1216,30 @@ Payload = Types::Hash[
 ]
 ```
 
+#### Attribute writers
+
+By default `Types::Data` classes are inmutable, but you can define attribute writers to allow for mutation using the `writer: true` option.
+
+```ruby
+class DBConfig < Types::Data
+  attribute :host, Types::String.default('localhost'), writer: true
+end
+
+class Config < Types::Data
+  attribute :host, Types::Forms::URI::HTTP, writer: true
+  attribute :port, Types::Integer.default(80), writer: true
+
+  # Nested structs can have writers too
+  attribute :db, DBConfig.default(DBConfig.new)
+end
+
+config = Config.new
+config.host = 'http://localhost'
+config.db.host = 'db.local'
+config.valid? # true
+config.errors # {}
+```
+
 #### Recursive struct definitions
 
 You can use `#defer`. See [recursive types](#recursive-types).

--- a/lib/plumb/attributes.rb
+++ b/lib/plumb/attributes.rb
@@ -117,6 +117,7 @@ module Plumb
 
     def initialize(attrs = {})
       assign_attributes(attrs)
+      freeze
     end
 
     def ==(other)

--- a/lib/plumb/attributes.rb
+++ b/lib/plumb/attributes.rb
@@ -257,7 +257,7 @@ module Plumb
           if result.valid?
             @errors.delete(name)
           else
-            @errors.merge!(result.errors)
+            @errors.merge!(name => result.errors)
           end
           result.value
         end

--- a/spec/data_spec.rb
+++ b/spec/data_spec.rb
@@ -327,4 +327,25 @@ RSpec.describe Types::Data do
     expect { obj.age }.to raise_error(NoMethodError)
     expect(obj.full).to eq('Joe (20)')
   end
+
+  specify 'writer: true' do
+    klass = Class.new(Types::Data) do
+      attribute :host, Types::Forms::URI::HTTP, writer: true
+      attribute :port, Types::Lax::Integer.default(80), writer: true
+      attribute :thing do
+        attribute :name, String, writer: true
+      end
+    end
+
+    config = klass.new(thing: { name: 'foo' })
+    expect(config.valid?).to be false
+    expect(config.port).to eq 80
+
+    config.host = 'http://example.com'
+    expect(config.valid?).to be true
+    expect(config.host).to be_a(URI::HTTP)
+    expect(config.thing.name).to eq 'foo'
+    expect(config.thing.name = 'bar').to eq 'bar'
+    expect(config.thing.name).to eq 'bar'
+  end
 end

--- a/spec/data_spec.rb
+++ b/spec/data_spec.rb
@@ -314,4 +314,17 @@ RSpec.describe Types::Data do
     expect(class_a === a).to be true
     expect(class_b === a).to be false
   end
+
+  specify 'private attributes' do
+    klass = Class.new(Types::Data) do
+      attribute :name, String
+      private attribute :age, Integer
+
+      def full = "#{name} (#{age})"
+    end
+
+    obj = klass.new(name: 'Joe', age: 20)
+    expect { obj.age }.to raise_error(NoMethodError)
+    expect(obj.full).to eq('Joe (20)')
+  end
 end

--- a/spec/data_spec.rb
+++ b/spec/data_spec.rb
@@ -347,5 +347,9 @@ RSpec.describe Types::Data do
     expect(config.thing.name).to eq 'foo'
     expect(config.thing.name = 'bar').to eq 'bar'
     expect(config.thing.name).to eq 'bar'
+
+    config.host = 10
+    expect(config.valid?).to be false
+    expect(config.errors[:host].any?).to be true
   end
 end


### PR DESCRIPTION
By default `Types::Data` classes are inmutable, but you can define attribute writers to allow for mutation using the `writer: true` option.

```ruby
class DBConfig < Types::Data
  attribute :host, Types::String.default('localhost'), writer: true
end

class Config < Types::Data
  attribute :host, Types::Forms::URI::HTTP, writer: true
  attribute :port, Types::Integer.default(80), writer: true

  # Nested structs can have writers too
  attribute :db, DBConfig.default(DBConfig.new)
end

config = Config.new
config.host = 'http://localhost'
config.db.host = 'db.local'
config.valid? # true
config.errors # {}
```
