### PR TITLE
With helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -328,6 +328,28 @@ type.resolve(['a', 'a', 'b']) # Valid
 type.resolve(['a', 'x', 'b']) # Failure
 ```
 
+### `#with`
+
+The `#with` helper matches attributes of the object with values, using `#===`.
+
+```ruby
+LimitedArray = Types::Array[String].with(size: 10)
+LimitedString = Types::String.with(size: 10)
+LimitedSet = Types::Any[Set].with(size: 10)
+```
+
+The size is matched via `#===`, so ranges also work.
+
+```ruby
+Password = Types::String.with(bytesize: 10..20)
+```
+
+The helper accepts multiple attribute/valye pairs
+
+```ruby
+JoeBloggs = Types::Any[User].with(first_name: 'Joe', last_name: 'Bloggs')
+```
+
 #### `#transform`
 
 Transform value. Requires specifying the resulting type of the value after transformation.
@@ -588,23 +610,7 @@ The opposite of `#options`, this policy validates that the value _is not_ includ
 Name = Types::String.policy(excluded_from: ['Joe', 'Joan'])
 ```
 
-#### `:size`
-
-Works for any value that responds to `#size` and validates that the value's size matches the argument.
-
-```ruby
-LimitedArray = Types::Array[String].policy(size: 10)
-LimitedString = Types::String.policy(size: 10)
-LimitedSet = Types::Any[Set].policy(size: 10)
-```
-
-The size is matched via `#===`, so ranges also work.
-
-```ruby
-Password = Types::String.policy(size: 10..20)
-```
-
-#### `:split` (strings only)
+#### :split` (strings only)
 
 Splits string values by a separator (default: `,`).
 

--- a/lib/plumb/attribute_value_match.rb
+++ b/lib/plumb/attribute_value_match.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module Plumb
+  class AttributeValueMatch
+    include Composable
+
+    attr_reader :type, :attr_name, :value
+
+    def initialize(type, attr_name, value)
+      @type = type
+      @attr_name = attr_name
+      @value = value
+      @error = "must have attribute #{attr_name} === #{value.inspect}"
+      freeze
+    end
+
+    def metadata = type.metadata
+
+    def call(result)
+      return result if value === result.value.public_send(attr_name)
+
+      result.invalid(errors: @error)
+    end
+  end
+end

--- a/lib/plumb/composable.rb
+++ b/lib/plumb/composable.rb
@@ -273,15 +273,16 @@ module Plumb
     class Node
       include Composable
 
-      attr_reader :node_name, :type, :attributes
+      attr_reader :node_name, :type, :args
 
-      def initialize(node_name, type, attributes = BLANK_HASH)
+      def initialize(node_name, type, args = BLANK_HASH)
         @node_name = node_name
         @type = type
-        @attributes = attributes
+        @args = args
         freeze
       end
 
+      def metadata = type.metadata
       def call(result) = type.call(result)
     end
 
@@ -291,10 +292,10 @@ module Plumb
     # Ex. Types::Boolean is a compoition of Types::True | Types::False, but we want to treat it as a single node.
     #
     # @param node_name [Symbol]
-    # @param metadata [Hash]
+    # @param args [Hash]
     # @return [Node]
-    def as_node(node_name, metadata = BLANK_HASH)
-      Node.new(node_name, self, metadata)
+    def as_node(node_name, args = BLANK_HASH)
+      Node.new(node_name, self, args)
     end
 
     # Register a policy for this step.

--- a/lib/plumb/composable.rb
+++ b/lib/plumb/composable.rb
@@ -298,36 +298,15 @@ module Plumb
       Node.new(node_name, self, args)
     end
 
-    class AttributeValueMatch
-      include Composable
-
-      attr_reader :type, :attr_name, :value
-
-      def initialize(type, attr_name, value)
-        @type = type
-        @attr_name = attr_name
-        @value = value
-        @error = "must have attribute #{attr_name} === #{value.inspect}"
-        freeze
-      end
-
-      def metadata = type.metadata
-
-      def call(result)
-        return result if value === result.value.public_send(attr_name)
-
-        result.invalid(errors: @error)
-      end
-    end
-
     # Check attributes of an object against values, using #===
     # @example
-    #   type = Types::String.with(size: 1..10)
+    #   type = Types::Array.with(size: 1..10)
+    #   type = Types::String.with(bytesize: 1..10)
     #
     # @param attrs [Hash]
     def with(attrs)
       attrs.reduce(self) do |t, (name, value)|
-        AttributeValueMatch.new(t, name, value)
+        t >> AttributeValueMatch.new(t, name, value)
       end
     end
 
@@ -459,6 +438,7 @@ module Plumb
 end
 
 require 'plumb/deferred'
+require 'plumb/attribute_value_match'
 require 'plumb/transform'
 require 'plumb/policy'
 require 'plumb/build'

--- a/lib/plumb/composable.rb
+++ b/lib/plumb/composable.rb
@@ -298,6 +298,39 @@ module Plumb
       Node.new(node_name, self, args)
     end
 
+    class AttributeValueMatch
+      include Composable
+
+      attr_reader :type, :attr_name, :value
+
+      def initialize(type, attr_name, value)
+        @type = type
+        @attr_name = attr_name
+        @value = value
+        @error = "must have attribute #{attr_name} === #{value.inspect}"
+        freeze
+      end
+
+      def metadata = type.metadata
+
+      def call(result)
+        return result if value === result.value.public_send(attr_name)
+
+        result.invalid(errors: @error)
+      end
+    end
+
+    # Check attributes of an object against values, using #===
+    # @example
+    #   type = Types::String.with(size: 1..10)
+    #
+    # @param attrs [Hash]
+    def with(attrs)
+      attrs.reduce(self) do |t, (name, value)|
+        AttributeValueMatch.new(t, name, value)
+      end
+    end
+
     # Register a policy for this step.
     # Mode 1.a: #policy(:name, arg) a single policy with an argument
     # Mode 1.b: #policy(:name) a single policy without an argument

--- a/lib/plumb/json_schema_visitor.rb
+++ b/lib/plumb/json_schema_visitor.rb
@@ -138,13 +138,22 @@ module Plumb
       end
     end
 
+    on(:attribute_value_match) do |node, props|
+      method_name = :"visit_with_#{node.attr_name}_attribute"
+      if respond_to?(method_name)
+        send(method_name, node, props)
+      else
+        props
+      end
+    end
+
     on(:options_policy) do |node, props|
       props.merge(ENUM => node.arg)
     end
 
-    on(:with_size) do |node, props|
+    on(:with_size_attribute) do |node, props|
       opts = visit(node.type)
-      value = node.args[:size]
+      value = node.value
 
       case opts[TYPE]
       when 'array'

--- a/lib/plumb/json_schema_visitor.rb
+++ b/lib/plumb/json_schema_visitor.rb
@@ -142,26 +142,28 @@ module Plumb
       props.merge(ENUM => node.arg)
     end
 
-    on(:size_policy) do |node, props|
-      opts = {}
-      case props[TYPE]
+    on(:with_size) do |node, props|
+      opts = visit(node.type)
+      value = node.args[:size]
+
+      case opts[TYPE]
       when 'array'
-        case node.arg
+        case value
         when Range
-          opts[MIN_ITEMS] = node.arg.min if node.arg.begin
-          opts[MAX_ITEMS] = node.arg.max if node.arg.end
+          opts[MIN_ITEMS] = value.min if value.begin
+          opts[MAX_ITEMS] = value.max if value.end
         when Numeric
-          opts[MIN_ITEMS] = node.arg
-          opts[MAX_ITEMS] = node.arg
+          opts[MIN_ITEMS] = value
+          opts[MAX_ITEMS] = value
         end
       when 'string'
-        case node.arg
+        case value
         when Range
-          opts[MIN_LENGTH] = node.arg.min if node.arg.begin
-          opts[MAX_LENGTH] = node.arg.max if node.arg.end
+          opts[MIN_LENGTH] = value.min if value.begin
+          opts[MAX_LENGTH] = value.max if value.end
         when Numeric
-          opts[MIN_LENGTH] = node.arg
-          opts[MAX_LENGTH] = node.arg
+          opts[MIN_LENGTH] = value
+          opts[MAX_LENGTH] = value
         end
       end
 

--- a/lib/plumb/schema.rb
+++ b/lib/plumb/schema.rb
@@ -178,6 +178,11 @@ module Plumb
         self
       end
 
+      def with(...)
+        @_type = @_type.with(...)
+        self
+      end
+
       def inspect
         "#{self.class}[#{@_type.inspect}]"
       end

--- a/lib/plumb/types.rb
+++ b/lib/plumb/types.rb
@@ -13,7 +13,9 @@ module Plumb
   #   type = Types::String.with(size: 1..10)
   policy :with, helper: true do |type, opts|
     opts.reduce(type) do |t, (name, value)|
-      t.check("must have attribute #{name} === #{value.inspect}") { |v| value === v.public_send(name) }
+      t.check("must have attribute #{name} === #{value.inspect}") do |v| 
+        value === v.public_send(name)
+      end.as_node(:"with_#{name}", name => value)
     end
   end
 
@@ -51,17 +53,6 @@ module Plumb
     type.check("must not be included in #{opts.inspect}") do |v|
       !opts.include?(v)
     end
-  end
-
-  # Validate #size against a number or any object that responds to #===.
-  # This works with any type that repsonds to #size.
-  # Usage:
-  #   type = Types::String.policy(size: 10)
-  #   type = Types::Integer.policy(size: 1..10)
-  #   type = Types::Array.policy(size: 1..)
-  #   type = Types::Any[Set].policy(size: 1..)
-  policy :size, for_type: :size do |type, size|
-    type.check("must be of size #{size}") { |v| size === v.size }
   end
 
   # Validate that an object is not #empty? nor #nil?

--- a/lib/plumb/types.rb
+++ b/lib/plumb/types.rb
@@ -7,6 +7,16 @@ require 'time'
 
 module Plumb
   # Define core policies
+  #
+  # Check attributes of an object against values, using #===
+  # @example
+  #   type = Types::String.with(size: 1..10)
+  policy :with, helper: true do |type, opts|
+    opts.reduce(type) do |t, (name, value)|
+      t.check("must have attribute #{name} === #{value.inspect}") { |v| value === v.public_send(name) }
+    end
+  end
+
   # Allowed options for an array type.
   # It validates that each element is in the options array.
   # Usage:

--- a/lib/plumb/types.rb
+++ b/lib/plumb/types.rb
@@ -8,17 +8,6 @@ require 'time'
 module Plumb
   # Define core policies
   #
-  # Check attributes of an object against values, using #===
-  # @example
-  #   type = Types::String.with(size: 1..10)
-  policy :with, helper: true do |type, opts|
-    opts.reduce(type) do |t, (name, value)|
-      t.check("must have attribute #{name} === #{value.inspect}") do |v| 
-        value === v.public_send(name)
-      end.as_node(:"with_#{name}", name => value)
-    end
-  end
-
   # Allowed options for an array type.
   # It validates that each element is in the options array.
   # Usage:

--- a/spec/json_schema_visitor_spec.rb
+++ b/spec/json_schema_visitor_spec.rb
@@ -74,14 +74,14 @@ RSpec.describe Plumb::JSONSchemaVisitor do
     expect(described_class.visit(type)).to eq('type' => 'string')
   end
 
-  specify 'Types::String with :size policy' do
-    type = Types::String.policy(size: (10..20))
+  specify 'Types::String with :size attribute check' do
+    type = Types::String.with(size: (10..20))
     expect(described_class.visit(type)).to eq('type' => 'string', 'minLength' => 10, 'maxLength' => 20)
 
-    type = Types::String.policy(size: (10..))
+    type = Types::String.with(size: (10..))
     expect(described_class.visit(type)).to eq('type' => 'string', 'minLength' => 10)
 
-    type = Types::String.policy(size: 20)
+    type = Types::String.with(size: 20)
     expect(described_class.visit(type)).to eq('type' => 'string', 'minLength' => 20, 'maxLength' => 20)
   end
 
@@ -244,7 +244,7 @@ RSpec.describe Plumb::JSONSchemaVisitor do
 
   describe 'Types::Array with :size policy' do
     it 'works with inclusive Ranges' do
-      type = Types::Array[Types::Integer].policy(size: (10..20))
+      type = Types::Array[Types::Integer].with(size: (10..20))
       expect(described_class.visit(type)).to eq(
         'type' => 'array',
         'items' => { 'type' => 'integer' },
@@ -254,7 +254,7 @@ RSpec.describe Plumb::JSONSchemaVisitor do
     end
 
     it 'works with exclusive Ranges' do
-      type = Types::Array[Types::Integer].policy(size: (10...20))
+      type = Types::Array[Types::Integer].with(size: (10...20))
       expect(described_class.visit(type)).to eq(
         'type' => 'array',
         'items' => { 'type' => 'integer' },
@@ -264,7 +264,7 @@ RSpec.describe Plumb::JSONSchemaVisitor do
     end
 
     it 'works with open Ranges' do
-      type = Types::Array[Types::Integer].policy(size: (10...))
+      type = Types::Array[Types::Integer].with(size: (10...))
       expect(described_class.visit(type)).to eq(
         'type' => 'array',
         'items' => { 'type' => 'integer' },

--- a/spec/json_schema_visitor_spec.rb
+++ b/spec/json_schema_visitor_spec.rb
@@ -83,6 +83,10 @@ RSpec.describe Plumb::JSONSchemaVisitor do
 
     type = Types::String.with(size: 20)
     expect(described_class.visit(type)).to eq('type' => 'string', 'minLength' => 20, 'maxLength' => 20)
+
+    # Ignores unregistered attribute matchers
+    type = Types::String.with(size: 20, bytesize: 10)
+    expect(described_class.visit(type)).to eq('type' => 'string', 'minLength' => 20, 'maxLength' => 20)
   end
 
   specify 'Types::String with :split policy' do

--- a/spec/plumb_spec.rb
+++ b/spec/plumb_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Plumb do
 
   describe '.decorate' do
     it 'finds and replaces a step' do
-      name = Types::String.policy(size: 1..10)
+      name = Types::String.with(size: 1..10)
       type = Types::Array[name].default([].freeze)
       type2 = Plumb.decorate(type) do |node|
         if node.is_a?(Plumb::ArrayClass)

--- a/spec/schema_spec.rb
+++ b/spec/schema_spec.rb
@@ -169,7 +169,7 @@ RSpec.describe Plumb::Schema do
     s1 = described_class.new do |sc|
       sc.field(:friends, Types::Array) do |f|
         f.field(:name, Types::String)
-      end.policy(size: (1..))
+      end.with(size: (1..))
     end
 
     result = s1.resolve(friends: [{ name: 'Joe' }])

--- a/spec/types_spec.rb
+++ b/spec/types_spec.rb
@@ -368,6 +368,16 @@ RSpec.describe Plumb::Types do
     end
   end
 
+  describe '#with' do
+    it 'validates properties of the object' do
+      assert_result(Types::Array.with(size: 2).resolve([1]), [1], false)
+      assert_result(Types::Array.with(size: 2).resolve([1, 2]), [1, 2], true)
+      assert_result(Types::String.with(size: 2).resolve('ab'), 'ab', true)
+      assert_result(Types::Array.with(size: 1..2).resolve([1, 2]), [1, 2], true)
+      assert_result(Types::Array.with(size: 1..2).resolve([1, 2, 3]), [1, 2, 3], false)
+    end
+  end
+
   describe '#policy' do
     specify ':size' do
       assert_result(Types::Array.policy(size: 2).resolve([1]), [1], false)

--- a/spec/types_spec.rb
+++ b/spec/types_spec.rb
@@ -379,14 +379,8 @@ RSpec.describe Plumb::Types do
   end
 
   describe '#policy' do
-    specify ':size' do
-      assert_result(Types::Array.policy(size: 2).resolve([1]), [1], false)
-      assert_result(Types::Array.policy(size: 2).resolve([1, 2]), [1, 2], true)
-      assert_result(Types::String.policy(size: 2).resolve('ab'), 'ab', true)
-    end
-
     specify 'registering rule as :name, value' do
-      assert_result(Types::Array.policy(:size, 1).resolve([1]), [1], true)
+      assert_result(Types::Array.policy(:options, [1]).resolve([1]), [1], true)
     end
 
     specify ':options' do
@@ -659,7 +653,7 @@ RSpec.describe Plumb::Types do
     end
 
     specify 'pattern matching' do
-      Types::String.policy(size: 3)
+      Types::String.with(size: 3)
       [:ok, 'sup'] => [symbol => sym, three_chars => chars]
 
       expect(sym).to eq(:ok)


### PR DESCRIPTION
### `#with`

The `#with` helper matches attributes of the object with values, using `#===`.

```ruby
LimitedArray = Types::Array[String].with(size: 10)
LimitedString = Types::String.with(size: 10)
LimitedSet = Types::Any[Set].with(size: 10)
```

The size is matched via `#===`, so ranges also work.

```ruby
Password = Types::String.with(bytesize: 10..20)
```

The helper accepts multiple attribute/valye pairs

```ruby
JoeBloggs = Types::Any[User].with(first_name: 'Joe', last_name: 'Bloggs')
```
