### PR TITLE
Reuse Result instances to cut per-node allocations

### DIFF
--- a/bench/compare_parametric_schema.rb
+++ b/bench/compare_parametric_schema.rb
@@ -7,90 +7,12 @@ require 'benchmark/ips'
 require 'money'
 Money.rounding_mode = BigDecimal::ROUND_HALF_EVEN
 Money.default_currency = 'GBP'
+require_relative './sample_data'
 require_relative './parametric_schema'
 require_relative './plumb_hash'
 
-data = {
-  supplier_name: 'Vodafone',
-  start_date: '2020-01-01',
-  end_date: '2021-01-11',
-  countdown_date: '2021-01-11',
-  name: 'Vodafone TV',
-  upfront_cost_description: 'Upfront cost description',
-  tv_channels_count: 100,
-  terms: [
-    { name: 'Foo', url: 'http://foo.com', terms_text: 'Foo terms', start_date: '2020-01-01', end_date: '2021-01-01' },
-    { name: 'Foo2', url: 'http://foo2.com', terms_text: 'Foo terms', start_date: '2020-01-01', end_date: '2021-01-01' }
-  ],
-  tv_included: true,
-  additional_info: 'Additional info',
-  product_type: 'TV',
-  annual_price_increase_applies: true,
-  annual_price_increase_description: 'Annual price increase description',
-  broadband_components: [
-    {
-      name: 'Broadband 1',
-      technology: 'FTTP',
-      technology_tags: ['FTTP'],
-      is_mobile: false,
-      description: 'Broadband 1 description',
-      download_speed_measurement: 'Mbps',
-      download_speed: 100,
-      upload_speed_measurement: 'Mbps',
-      upload_speed: 100,
-      download_usage_limit: 1000,
-      discount_price: 100,
-      discount_period: 12,
-      speed_description: 'Speed description',
-      ongoing_price: 100,
-      contract_length: 12,
-      upfront_cost: 100,
-      commission: 100
-    }
-  ],
-  tv_components: [
-    {
-      slug: 'vodafone-tv',
-      name: 'Vodafone TV',
-      search_tags: %w[Vodafone TV],
-      description: 'Vodafone TV description',
-      channels: 100,
-      discount_price: 100
-    }
-  ],
-  call_package_types: ['Everything'],
-  phone_components: [
-    {
-      name: 'Phone 1',
-      description: 'Phone 1 description',
-      discount_price: 100,
-      discount_period: 12,
-      ongoing_price: 100,
-      contract_length: 12,
-      upfront_cost: 100,
-      commission: 100,
-      call_package_types: ['Everything']
-    }
-  ],
-  payment_methods: ['Credit Card', 'Paypal'],
-  discounts: [
-    { period: 12, price: 100 }
-  ],
-  ongoing_price: 100,
-  contract_length: 12,
-  upfront_cost: 100,
-  year_1_price: 100,
-  savings: 100,
-  commission: 100,
-  max_broadband_download_speed: 100
-}
+data = SAMPLE_DATA
 
-# p V1Schemas::RECORD.resolve(data).errors
-# p V2Schemas::Record.resolve(data)
-# result = Parametric::V2::Result.wrap(data)
-
-# p result
-# p V2Schema.call(result)
 Benchmark.ips do |x|
   x.report('Parametric::Schema') do
     ParametricSchema::RECORD.resolve(data)

--- a/lib/plumb/array_class.rb
+++ b/lib/plumb/array_class.rb
@@ -38,17 +38,19 @@ module Plumb
           r = element_type.resolve(e)
           memo << r.value if r.valid?
         end
-        result.valid(arr)
+        result.valid!(arr)
       end
     end
 
     def call(result)
-      return result.invalid(errors: 'is not an Array') unless ::Array === result.value
+      return result.invalid!(errors: 'is not an Array') unless ::Array === result.value
 
+      # map_array_elements uses its own element scratch (below), so `result` is
+      # untouched until here — flip it in place rather than allocating a fresh one.
       values, errors = map_array_elements(result)
-      return result.valid(values) unless errors.any?
+      return result.valid!(values) unless errors.any?
 
-      result.invalid(values, errors:)
+      result.invalid!(values, errors:)
     end
 
     private
@@ -60,14 +62,19 @@ module Plumb
     end
 
     def map_array_elements(result)
-      # Reuse the same result object for each element
-      # to decrease object allocation.
-      # Steps might return the same result instance, so we map the values directly
-      # separate from the errors.
-      element_result = result.dup
-      errors = Hash.new(capacity: result.value.size)
-      values = result.value.map.with_index do |e, idx|
-        re = element_type.call(element_result.reset(e))
+      # Reuse the INCOMING cursor as the per-element scratch (capturing the array
+      # first): each element flips it in place via #reset, and #call flips it a
+      # final time to the collected values — so a sequential Array validates with
+      # zero Result allocations of its own. Steps may return the same result
+      # instance, so map values/errors out immediately rather than holding `re`.
+      #
+      # Element types that produce a value which is lazily consumed later (a
+      # Stream) must not close over this reused cursor — StreamClass#call
+      # snapshots its source for exactly this reason (see there).
+      array = result.value
+      errors = Hash.new(capacity: array.size)
+      values = array.map.with_index do |e, idx|
+        re = element_type.call(result.reset(e))
         errors[idx] = re.errors unless re.valid?
         re.value
       end

--- a/lib/plumb/attribute_value_match.rb
+++ b/lib/plumb/attribute_value_match.rb
@@ -58,7 +58,7 @@ module Plumb
     def call(result)
       return result if value === result.value.public_send(attr_name)
 
-      result.invalid(errors: @error)
+      result.invalid!(errors: @error)
     end
 
     private def _inspect = @inspect_line

--- a/lib/plumb/composable.rb
+++ b/lib/plumb/composable.rb
@@ -629,8 +629,11 @@ module Plumb
     # callable, and declares `target_type` as the (validated) output type.
     private def transform_step(target_type, callable, guaranteed: false)
       klass = guaranteed ? GuaranteedTransform : Transform
+      # Flip the cursor in place with the transformed value — the transform owns
+      # the result it is handed (the argument is evaluated first, reading the
+      # pre-transform value), so no fresh Result is needed.
       klass.new(self, Composable.wrap(target_type),
-                ->(result) { result.valid(callable.call(result.value)) })
+                ->(result) { result.valid!(callable.call(result.value)) })
     end
 
     # Expand `#transform(:to_i)` into a typed transform to `output_type`, using

--- a/lib/plumb/composable.rb
+++ b/lib/plumb/composable.rb
@@ -23,7 +23,6 @@ module Plumb
   BLANK_STRING = ''
   BLANK_ARRAY = [].freeze
   BLANK_HASH = {}.freeze
-  BLANK_RESULT = Result.wrap(Undefined)
   NOOP = ->(result) { result }
 
   # Ruby's explicit conversion methods and the type each produces. Lets

--- a/lib/plumb/constraint.rb
+++ b/lib/plumb/constraint.rb
@@ -139,7 +139,7 @@ module Plumb
         return result unless result.valid?
       end
 
-      @matcher === result.value ? result : result.invalid(errors: @error)
+      @matcher === result.value ? result : result.invalid!(errors: @error)
     end
 
     private

--- a/lib/plumb/hash_class.rb
+++ b/lib/plumb/hash_class.rb
@@ -93,17 +93,16 @@ module Plumb
         return result unless _schema.any?
 
         input = result.value
-        field_result = BLANK_RESULT.dup
+        # Reuse the incoming cursor as the per-field scratch (see #call): `input`
+        # is captured above and `result` is only flipped at the end, so fields
+        # reset it in place with no scratch allocation.
         output = _schema.each.with_object({}) do |(key, field), ret|
           key_s = key.to_sym
           if input.key?(key_s)
-            r = field.call(field_result.reset(input[key_s]))
+            r = field.call(result.reset(input[key_s]))
             ret[key_s] = r.value if r.valid?
           elsif !key.optional?
-            # Reuse the scratch (reset to Undefined) rather than the shared
-            # BLANK_RESULT constant: fields now flip the cursor in place, and
-            # mutating the shared constant would corrupt it process-wide.
-            r = field.call(field_result.reset(Undefined))
+            r = field.call(result.reset(Undefined))
             ret[key_s] = r.value if r.valid?
           end
         end
@@ -128,21 +127,26 @@ module Plumb
       input = result.value
       errors = nil # Do not allocate errors unless needed
       output = @inclusive ? input.dup : {}
-      field_result = Result.valid(nil)
 
+      # Reuse the incoming cursor as the per-field scratch: `input` is captured
+      # above and `result` is not read again until the final flip below, so each
+      # field can reset it in place — a Hash validates with zero Result
+      # allocations of its own. `output`/`errors` hold the fields' values/errors
+      # by reference (read out immediately per field), and #reset only reassigns
+      # the cursor's slots, so previously stored entries are never mutated. This
+      # mirrors ArrayClass's element-cursor reuse; a field whose value is lazily
+      # consumed later (a Stream) snapshots its own source, so it stays correct.
       _schema.each do |key, field|
         key_s = key.to_key
         if input.key?(key_s)
-          r = field.call(field_result.reset(input[key_s]))
+          r = field.call(result.reset(input[key_s]))
           output[key_s] = r.value
           unless r.valid?
             errors ||= {}
             errors[key_s] = r.errors
           end
         elsif !key.optional?
-          # See #filtered: pass the scratch, never the shared BLANK_RESULT,
-          # since fields may now flip the cursor in place.
-          r = field.call(field_result.reset(Undefined))
+          r = field.call(result.reset(Undefined))
           output[key_s] = r.value unless r.value == Undefined
           unless r.valid?
             errors ||= {}

--- a/lib/plumb/hash_class.rb
+++ b/lib/plumb/hash_class.rb
@@ -89,7 +89,7 @@ module Plumb
     # participates in subtyping (see FilteredHash).
     def filtered
       op = lambda do |result|
-        return result.invalid(errors: 'must be a Hash') unless result.value.is_a?(::Hash)
+        return result.invalid!(errors: 'must be a Hash') unless result.value.is_a?(::Hash)
         return result unless _schema.any?
 
         input = result.value
@@ -100,11 +100,14 @@ module Plumb
             r = field.call(field_result.reset(input[key_s]))
             ret[key_s] = r.value if r.valid?
           elsif !key.optional?
-            r = field.call(BLANK_RESULT)
+            # Reuse the scratch (reset to Undefined) rather than the shared
+            # BLANK_RESULT constant: fields now flip the cursor in place, and
+            # mutating the shared constant would corrupt it process-wide.
+            r = field.call(field_result.reset(Undefined))
             ret[key_s] = r.value if r.valid?
           end
         end
-        result.valid(output)
+        result.valid!(output)
       end
       FilteredHash.new(self, relaxed_to_optional, op)
     end
@@ -119,7 +122,7 @@ module Plumb
     end
 
     def call(result)
-      return result.invalid(errors: NOT_A_HASH) unless result.value.is_a?(::Hash)
+      return result.invalid!(errors: NOT_A_HASH) unless result.value.is_a?(::Hash)
       return result unless _schema.any?
 
       input = result.value
@@ -137,7 +140,9 @@ module Plumb
             errors[key_s] = r.errors
           end
         elsif !key.optional?
-          r = field.call(BLANK_RESULT)
+          # See #filtered: pass the scratch, never the shared BLANK_RESULT,
+          # since fields may now flip the cursor in place.
+          r = field.call(field_result.reset(Undefined))
           output[key_s] = r.value unless r.value == Undefined
           unless r.valid?
             errors ||= {}
@@ -146,7 +151,7 @@ module Plumb
         end
       end
 
-      errors ? result.invalid(output, errors:) : result.valid(output)
+      errors ? result.invalid!(output, errors:) : result.valid!(output)
     end
 
     def ==(other)

--- a/lib/plumb/hash_map.rb
+++ b/lib/plumb/hash_map.rb
@@ -27,7 +27,7 @@ module Plumb
     end
 
     def call(result)
-      return result.invalid(errors: 'must be a Hash') unless result.value.is_a?(::Hash)
+      return result.invalid!(errors: 'must be a Hash') unless result.value.is_a?(::Hash)
 
       errors = {}
 
@@ -41,7 +41,7 @@ module Plumb
         memo[key_r.value] = value_r.value
       end
 
-      errors.empty? ? result.valid(parsed) : result.invalid(errors:)
+      errors.empty? ? result.valid!(parsed) : result.invalid!(errors:)
     end
 
     def filtered
@@ -78,7 +78,7 @@ module Plumb
           memo[key_r.value] = value_r.value if key_r.valid? && value_r.valid?
         end
 
-        result.valid(hash)
+        result.valid!(hash)
       end
 
       private def _inspect = "HashMap[#{@key_type.inspect}, #{@value_type.inspect}].filtered"

--- a/lib/plumb/interface_class.rb
+++ b/lib/plumb/interface_class.rb
@@ -78,7 +78,7 @@ module Plumb
     def call(result)
       obj = result.value
       missing_methods = @method_names.reject { |m| obj.respond_to?(m) }
-      return result.invalid(errors: "Invalid #{self.name}. Missing methods: #{missing_methods.join(', ')}") if missing_methods.any?
+      return result.invalid!(errors: "Invalid #{self.name}. Missing methods: #{missing_methods.join(', ')}") if missing_methods.any?
 
       result
     end

--- a/lib/plumb/not.rb
+++ b/lib/plumb/not.rb
@@ -41,7 +41,8 @@ module Plumb
 
     def call(result)
       result = @step.call(result)
-      result.valid? ? result.invalid(errors: @errors) : result.valid
+      # In-place inversion — no fork here, the cursor is ours to flip.
+      result.valid? ? result.invalid!(errors: @errors) : result.valid!
     end
   end
 end

--- a/lib/plumb/or.rb
+++ b/lib/plumb/or.rb
@@ -45,23 +45,29 @@ module Plumb
     end
 
     def call(result)
+      # Snapshot the input value: @left may flip the cursor to invalid in place,
+      # so we need the original to retry @right on the same object.
+      original = result.value
+
       left_result = @left.call(result)
       return left_result if left_result.valid?
 
-      right_result = @right.call(result)
-      if right_result.valid?
-        right_result
-      else
-        # Decrease Array allocations slightly
-        # OR can be really expensive in composite ORed types
-        left_errors = left_result.errors.is_a?(Array) ? left_result.errors : [left_result.errors]
-        right_errors = right_result.errors.is_a?(Array) ? right_result.errors.first : right_result.errors
-        left_errors << right_errors
+      # Capture left's errors before reusing the cursor — if @left mutated
+      # `result` in place, `left_result` IS `result` and the reset below would
+      # wipe them.
+      left_raw = left_result.errors
 
-        # right_result is a fresh Invalid we own — reuse it instead of allocating
-        # another just to swap in the merged errors.
-        right_result.with_errors(left_errors)
-      end
+      right_result = @right.call(result.reset(original))
+      return right_result if right_result.valid?
+
+      # Both branches failed. Merge errors (same flattening as before) and reuse
+      # right's already-invalid cursor in place rather than allocating another.
+      # OR can be really expensive in composite ORed types.
+      left_errors = left_raw.is_a?(Array) ? left_raw : [left_raw]
+      right_errors = right_result.errors.is_a?(Array) ? right_result.errors.first : right_result.errors
+      left_errors << right_errors
+
+      right_result.invalid!(errors: left_errors)
     end
   end
 end

--- a/lib/plumb/result.rb
+++ b/lib/plumb/result.rb
@@ -1,14 +1,38 @@
 # frozen_string_literal: true
 
 module Plumb
+  # The value + validity + errors triple that flows through a composition.
+  #
+  # There are two ways to derive one result from another:
+  #
+  #   - #valid / #invalid ALLOCATE a fresh Result and leave the receiver
+  #     untouched. This is the safe, functional form: use it in custom types, and
+  #     anywhere a result may outlive the call or be captured (Streams close over
+  #     it lazily; concurrent Arrays hand results between threads). This is the
+  #     public API for user-defined steps.
+  #
+  #   - #valid! / #invalid! FLIP THE RECEIVER in place and return it (no
+  #     allocation). Plumb's own built-in steps use these on the hot path to
+  #     avoid a Result per node — but only where the input cursor is theirs to
+  #     mutate: never on a shared/constant Result, never when the result escapes
+  #     into a closure or another thread. The one fork point (Or) snapshots the
+  #     value and #resets before retrying its second branch.
+  #
+  # So built-ins stay allocation-lean while user code (and the concurrency- and
+  # laziness-sensitive built-ins) keep the footgun-free copying semantics, at the
+  # cost of a few extra allocations there.
+  #
+  # Valid and Invalid were once separate subclasses; collapsing them into one
+  # class with a boolean is what makes the in-place valid<->invalid flip possible
+  # (Ruby can't change an object's class).
   class Result
     class << self
-      def valid(value)
-        Valid.new(value)
+      def valid(value = nil)
+        new(value, valid: true)
       end
 
       def invalid(value = nil, errors: nil)
-        Invalid.new(value, errors:)
+        new(value, valid: false, errors:)
       end
 
       def wrap(value)
@@ -20,31 +44,20 @@ module Plumb
 
     attr_reader :value, :errors
 
-    def initialize(value, errors: nil)
+    def initialize(value, valid: true, errors: nil)
       @value = value
+      @valid = valid
       @errors = errors
     end
 
-    def valid? = true
-    def invalid? = false
+    def valid? = @valid
+    def invalid? = !@valid
 
     def inspect
-      %(<#{self.class}##{object_id} value:#{value.inspect} errors:#{errors.inspect}>)
+      %(<#{self.class}##{object_id} valid:#{@valid} value:#{value.inspect} errors:#{errors.inspect}>)
     end
 
-    def reset(val)
-      @value = val
-      @errors = nil
-      self
-    end
-
-    # Replace this result's errors in place and return self. For reusing an
-    # already-allocated Invalid instead of building a fresh one (see Or#call).
-    def with_errors(errs)
-      @errors = errs
-      self
-    end
-
+    # Allocating, copy-returning form. Safe everywhere: the receiver is untouched.
     def valid(val = value)
       Result.valid(val)
     end
@@ -53,19 +66,31 @@ module Plumb
       Result.invalid(val, errors:)
     end
 
-    class Valid < self
-      def map(callable)
-        callable.call(self)
-      end
+    # In-place form: flip THIS result and return self. No allocation. Only for
+    # code that owns the cursor (see the class docstring).
+    def valid!(val = value)
+      @value = val
+      @valid = true
+      @errors = nil
+      self
     end
 
-    class Invalid < self
-      def valid? = false
-      def invalid? = true
+    def invalid!(val = value, errors: nil)
+      @value = val
+      @valid = false
+      @errors = errors
+      self
+    end
 
-      def map(_)
-        self
-      end
+    # Reset the cursor to a fresh VALID state carrying `val`, in place. The
+    # mutating scratch-reuse primitive behind the HashClass/ArrayClass element
+    # loops (same as #valid!(val)).
+    def reset(val)
+      valid!(val)
+    end
+
+    def map(callable)
+      @valid ? callable.call(self) : self
     end
   end
 end

--- a/lib/plumb/static_class.rb
+++ b/lib/plumb/static_class.rb
@@ -29,7 +29,7 @@ module Plumb
     def input_type = Types::Any
 
     def call(result)
-      result.valid(@value)
+      result.valid!(@value)
     end
 
     private

--- a/lib/plumb/stream_class.rb
+++ b/lib/plumb/stream_class.rb
@@ -51,12 +51,21 @@ module Plumb
       return result unless result.valid?
       # return result.invalid(errors: 'is not an Enumerable') unless result.value.respond_to?(:each)
 
+      # Snapshot the source enumerable into a local so the lazy Enumerator closes
+      # over IT, not the result cursor. The cursor may be reused/mutated after we
+      # return (eg. a Stream nested in an Array, whose cursor is reset per
+      # element) — closing over the snapshot keeps each stream bound to its own
+      # input regardless.
+      source = result.value
       enum = Enumerator.new do |y|
-        result.value.each do |e|
+        source.each do |e|
           y << @element_type.resolve(e)
         end
       end
 
+      # Copying #valid (not #valid!): the returned result's value IS the lazy
+      # enum, so the result must be a fresh object the caller can hold while its
+      # own cursor moves on.
       result.valid(enum)
     end
 

--- a/lib/plumb/tagged_hash.rb
+++ b/lib/plumb/tagged_hash.rb
@@ -34,7 +34,7 @@ module Plumb
       return result unless result.valid?
 
       child = @index[result.value[@key.to_sym]]
-      return result.invalid(errors: "expected :#{@key.to_sym} to be one of #{@index.keys.join(', ')}") unless child
+      return result.invalid!(errors: "expected :#{@key.to_sym} to be one of #{@index.keys.join(', ')}") unless child
 
       child.call(result)
     end

--- a/lib/plumb/tuple_class.rb
+++ b/lib/plumb/tuple_class.rb
@@ -20,8 +20,8 @@ module Plumb
     alias [] of
 
     def call(result)
-      return result.invalid(errors: 'must be an Array') unless result.value.is_a?(::Array)
-      return result.invalid(errors: 'must have the same size') unless result.value.size == @children.size
+      return result.invalid!(errors: 'must be an Array') unless result.value.is_a?(::Array)
+      return result.invalid!(errors: 'must have the same size') unless result.value.size == @children.size
 
       errors = {}
       values = @children.map.with_index do |type, idx|
@@ -31,9 +31,9 @@ module Plumb
         r.value
       end
 
-      return result.valid(values) unless errors.any?
+      return result.valid!(values) unless errors.any?
 
-      result.invalid(errors:)
+      result.invalid!(errors:)
     end
 
     private

--- a/lib/plumb/value_class.rb
+++ b/lib/plumb/value_class.rb
@@ -31,7 +31,7 @@ module Plumb
     def value_preserving? = true
 
     def call(result)
-      @value == result.value ? result : result.invalid(errors: @error)
+      @value == result.value ? result : result.invalid!(errors: @error)
     end
 
     private

--- a/spec/result_spec.rb
+++ b/spec/result_spec.rb
@@ -1,0 +1,146 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Plumb::Result do
+  describe 'factory methods' do
+    specify '.valid builds a valid result' do
+      r = described_class.valid(10)
+      expect(r.valid?).to be(true)
+      expect(r.invalid?).to be(false)
+      expect(r.value).to eq(10)
+      expect(r.errors).to be_nil
+    end
+
+    specify '.invalid builds an invalid result carrying value and errors' do
+      r = described_class.invalid(10, errors: 'nope')
+      expect(r.valid?).to be(false)
+      expect(r.invalid?).to be(true)
+      expect(r.value).to eq(10)
+      expect(r.errors).to eq('nope')
+    end
+
+    specify '.wrap passes through an existing Result and wraps a raw value' do
+      existing = described_class.valid(1)
+      expect(described_class.wrap(existing)).to be(existing)
+
+      wrapped = described_class.wrap(2)
+      expect(wrapped).to be_a(described_class)
+      expect(wrapped.value).to eq(2)
+      expect(wrapped.valid?).to be(true)
+    end
+  end
+
+  describe 'copying form (#valid / #invalid)' do
+    specify '#valid returns a NEW valid result and leaves the receiver untouched' do
+      original = described_class.invalid(1, errors: 'bad')
+      copy = original.valid(2)
+
+      expect(copy).not_to be(original)              # a distinct object
+      expect(copy.valid?).to be(true)
+      expect(copy.value).to eq(2)
+      expect(copy.errors).to be_nil
+
+      # receiver is unchanged
+      expect(original.valid?).to be(false)
+      expect(original.value).to eq(1)
+      expect(original.errors).to eq('bad')
+    end
+
+    specify '#valid with no argument copies the current value' do
+      original = described_class.valid(5)
+      copy = original.valid
+      expect(copy).not_to be(original)
+      expect(copy.value).to eq(5)
+    end
+
+    specify '#invalid returns a NEW invalid result and leaves the receiver untouched' do
+      original = described_class.valid(1)
+      copy = original.invalid(errors: 'bad')
+
+      expect(copy).not_to be(original)
+      expect(copy.invalid?).to be(true)
+      expect(copy.value).to eq(1)                   # defaults to current value
+      expect(copy.errors).to eq('bad')
+
+      expect(original.valid?).to be(true)           # receiver untouched
+      expect(original.errors).to be_nil
+    end
+  end
+
+  describe 'in-place form (#valid! / #invalid!)' do
+    specify '#invalid! flips the SAME object to invalid, keeping the value' do
+      result = described_class.valid(42)
+      returned = result.invalid!(errors: 'boom')
+
+      expect(returned).to be(result)                # same object
+      expect(result.invalid?).to be(true)
+      expect(result.value).to eq(42)               # value preserved by default
+      expect(result.errors).to eq('boom')
+    end
+
+    specify '#invalid! can replace the value as well' do
+      result = described_class.valid(1)
+      result.invalid!(2, errors: 'boom')
+      expect(result.value).to eq(2)
+      expect(result.invalid?).to be(true)
+    end
+
+    specify '#valid! flips the SAME object back to valid and clears errors' do
+      result = described_class.invalid(1, errors: 'bad')
+      returned = result.valid!(2)
+
+      expect(returned).to be(result)
+      expect(result.valid?).to be(true)
+      expect(result.value).to eq(2)
+      expect(result.errors).to be_nil
+    end
+
+    specify '#valid! with no argument keeps the current value but clears errors' do
+      result = described_class.invalid(7, errors: 'bad')
+      result.valid!
+      expect(result.valid?).to be(true)
+      expect(result.value).to eq(7)
+      expect(result.errors).to be_nil
+    end
+
+    specify 'round-trips valid <-> invalid on one object without allocating' do
+      result = described_class.valid(1)
+      expect(result.invalid!(errors: 'e1')).to be(result)
+      expect(result.valid!(2)).to be(result)
+      expect(result.invalid!(errors: 'e2')).to be(result)
+      expect(result.value).to eq(2)
+      expect(result.errors).to eq('e2')
+    end
+  end
+
+  describe '#reset' do
+    specify 'flips the SAME object to a fresh valid state carrying the new value' do
+      result = described_class.invalid(1, errors: 'bad')
+      returned = result.reset(9)
+
+      expect(returned).to be(result)
+      expect(result.valid?).to be(true)
+      expect(result.value).to eq(9)
+      expect(result.errors).to be_nil
+    end
+  end
+
+  describe '#map' do
+    specify 'a valid result invokes the callable with itself' do
+      result = described_class.valid(3)
+      seen = nil
+      out = result.map(->(r) { seen = r; described_class.valid(r.value * 2) })
+      expect(seen).to be(result)
+      expect(out.value).to eq(6)
+    end
+
+    specify 'an invalid result short-circuits, returning itself without calling' do
+      result = described_class.invalid(3, errors: 'bad')
+      called = false
+      out = result.map(->(_) { called = true; described_class.valid(0) })
+      expect(called).to be(false)
+      expect(out).to be(result)
+    end
+  end
+end

--- a/spec/stream_spec.rb
+++ b/spec/stream_spec.rb
@@ -24,6 +24,24 @@ RSpec.describe Plumb::Types::Stream do
     expect(stream.to_a).to eq [10, 20, 40]
   end
 
+  # Regression: ArrayClass reuses its own result cursor as the per-element
+  # scratch (resetting it for each element). A Stream element's Enumerator must
+  # close over its own snapshotted source, NOT that shared cursor — otherwise
+  # every nested stream would replay whatever the cursor last held.
+  describe 'nested in an Array (reused element cursor)' do
+    it 'binds each stream to its own source, even when consumed out of order' do
+      type = Types::Array[Types::Stream[Types::Lax::Integer]]
+      result = type.resolve([%w[1 2], %w[3 4], %w[5 6]])
+
+      expect(result.valid?).to be(true)
+      streams = result.value.to_a
+      expect(streams.size).to eq(3)
+      # Reverse (and hence deferred) consumption proves each Enumerator kept its
+      # own input rather than the array's since-mutated cursor.
+      expect(streams.reverse.map { |s| s.map(&:value) }).to eq([[5, 6], [3, 4], [1, 2]])
+    end
+  end
+
   private
 
   def assert_result(result, value, is_success, debug: false)


### PR DESCRIPTION
## Summary

Collapses the `Valid`/`Invalid` subclasses into a single `Result` class carrying a boolean, which enables an in-place valid↔invalid flip and lets Plumb's own built-in steps validate a `Hash`/`Array` with **zero `Result` allocations of their own** on the hot path.

Two ways to derive a result from another are now made explicit:

- **`#valid` / `#invalid`** — allocate a fresh `Result`, leave the receiver untouched. The safe, functional form and the public API for user-defined steps.
- **`#valid!` / `#invalid!`** — flip the receiver in place and return it (no allocation). Used by Plumb's built-ins on the hot path, but only where the input cursor is theirs to mutate.

## Changes

- **`Result`**: merge `Valid`/`Invalid` into one class with a `@valid` flag; add mutating `#valid!` / `#invalid!` / `#reset`; keep copying `#valid` / `#invalid`. Extensive docstring on when to use which.
- **`HashClass` / `ArrayClass`**: reuse the incoming cursor as the per-field/element scratch instead of `dup`-ing a fresh `Result` per node.
- **`Or`**: snapshot the input value before `@left` (which may mutate the cursor), capture left's errors before resetting, and reuse right's already-invalid cursor for the merged errors.
- **`StreamClass`**: snapshot the source enumerable into a local so the lazy `Enumerator` closes over it — not the reused cursor — and return a *copying* `#valid` so the caller can hold the lazy result while its own cursor moves on.
- Update remaining built-in steps to the `!` forms where they own the cursor.
- Add `spec/result_spec.rb` and stream coverage; extend the parametric-schema benchmark to compare against Dry::Types / Dry::Schema.

## Safety notes

The mutation is confined to code that owns the cursor. Laziness- and concurrency-sensitive built-ins (Streams, concurrent Arrays) keep the copying semantics, and `Or`'s fork point snapshots the value and resets before retrying its second branch.
