### PR TITLE
Deferred types: subtyping (incl. recursive) and JSON Schema via $ref/$defs

### DIFF
--- a/lib/plumb/composable.rb
+++ b/lib/plumb/composable.rb
@@ -243,6 +243,20 @@ module Plumb
     def input_type = self
     def output_type = self
 
+    # The type that carries this node's identity for the subtype relation. A
+    # value-preserving type IS its own identity (the default). A value-converting
+    # type is identified by what it *produces*, so it projects onto a DISTINCT
+    # type (see Transform#subtype_identity => output_type): Plumb::Subtyping.subtype?
+    # reduces `a <= b` to `produced(a) <= b` before consulting the leaf hooks.
+    #
+    # CONTRACT: only return a value other than `self` when that value is a
+    # genuinely different node. Returning `self` here is a no-op (subtype? guards
+    # with `!equal?(self)`, so it simply won't reduce); returning a node whose own
+    # #subtype_identity loops back would recurse forever. This is the extension
+    # point for building custom transforming types that play well with subtyping
+    # WITHOUT subclassing Transform.
+    def subtype_identity = self
+
     # The type this step accepts as the consumer of a `left >> self` chain — the
     # values its #call processes without rejecting outright. Defaults to what it
     # takes as input (its resolved #input_type): right for plain matchers and for

--- a/lib/plumb/deferred.rb
+++ b/lib/plumb/deferred.rb
@@ -14,13 +14,13 @@ module Plumb
     end
 
     def call(result)
-      cached_type.call(result)
+      type.call(result)
     end
 
-    private def cached_type
+    def type
       @lock.synchronize do
         @cached_type = @definition.call
-        self.define_singleton_method(:cached_type) do
+        self.define_singleton_method(:type) do
           @cached_type
         end
         @cached_type

--- a/lib/plumb/json_schema_visitor.rb
+++ b/lib/plumb/json_schema_visitor.rb
@@ -21,6 +21,8 @@ module Plumb
     NOT = 'not'
     ENUM = 'enum'
     CONST = 'const'
+    REF = '$ref'
+    DEFS = '$defs'
     ITEMS = 'items'
     PATTERN = 'pattern'
     MINIMUM = 'minimum'
@@ -39,7 +41,13 @@ module Plumb
     }.freeze
 
     def self.call(node, root: true)
-      data = new.visit(node)
+      visitor = new
+      data = visitor.visit(node)
+      # Deferred types register named entries in a `$defs` table and reference
+      # them by `$ref` (see the :deferred handler). Hoist that table to the top of
+      # the document so the root-relative `#/$defs/...` pointers resolve.
+      defs = visitor.defs
+      data = data.merge(DEFS => defs) unless defs.empty?
       data = ENVELOPE.merge(data) if root
       normalize_json(data)
     end
@@ -76,6 +84,27 @@ module Plumb
 
     private def stringify_keys(hash) = hash.transform_keys(&:to_s)
 
+    # The `$defs` table of materialized Deferred schemas built during this visit,
+    # hoisted to the document root by `.call`. Empty unless a Deferred was visited.
+    def defs = @defs || BLANK_HASH
+
+    # Register a Deferred under a stable `$defs` name and return that name. The
+    # name is assigned and recorded BEFORE the body is visited, so a self-reference
+    # encountered while materializing the body finds the name already present and
+    # emits a `$ref` instead of recursing forever. Keyed by the Deferred's identity
+    # so the same node always maps to the same `$ref`.
+    private def deferred_ref(node)
+      @defs ||= {}
+      @deferred_names ||= {}.compare_by_identity
+      existing = @deferred_names[node]
+      return existing if existing
+
+      name = "Deferred#{@deferred_names.size + 1}"
+      @deferred_names[node] = name
+      @defs[name] = visit(node.type)
+      name
+    end
+
     on(:any) do |_node, props|
       props
     end
@@ -98,11 +127,14 @@ module Plumb
       props
     end
 
-    # Trying to visit the deferred could go into infinite recursion
-    # if a type is deferring to itself
-    # Not clear what deferred types would mean for JSON Schema anyway.
+    # A Deferred materializes to a concrete type (via #type), but that type may
+    # reference the Deferred back (a recursive/self-referential schema), so we
+    # can't inline it — that would recurse forever. Instead each Deferred becomes a
+    # named `$defs` entry referenced by `$ref`, the standard JSON Schema idiom for
+    # recursion. `deferred_ref` builds the def (once) and returns its name; `.call`
+    # hoists the `$defs` table to the document root.
     on(:deferred) do |node, props|
-      props
+      props.merge(REF => "#/#{DEFS}/#{deferred_ref(node)}")
     end
 
     on(:hash) do |node, props|

--- a/lib/plumb/json_schema_visitor.rb
+++ b/lib/plumb/json_schema_visitor.rb
@@ -88,20 +88,23 @@ module Plumb
     # hoisted to the document root by `.call`. Empty unless a Deferred was visited.
     def defs = @defs || BLANK_HASH
 
-    # Register a Deferred under a stable `$defs` name and return that name. The
-    # name is assigned and recorded BEFORE the body is visited, so a self-reference
-    # encountered while materializing the body finds the name already present and
-    # emits a `$ref` instead of recursing forever. Keyed by the Deferred's identity
-    # so the same node always maps to the same `$ref`.
+    # Register a Deferred under a stable `$defs` name and return that name. Keyed
+    # by the RESOLVED target type's identity (not the Deferred wrapper's), so
+    # distinct `defer { … }` wrappers pointing at the same type share one def.
+    # Resolving via #type is cheap (memoized) and does no visitor recursion, so we
+    # can key on it up front. The name is recorded BEFORE the body is visited, so a
+    # self-reference encountered while visiting finds the name already present and
+    # emits a `$ref` instead of recursing forever.
     private def deferred_ref(node)
       @defs ||= {}
       @deferred_names ||= {}.compare_by_identity
-      existing = @deferred_names[node]
+      target = node.type
+      existing = @deferred_names[target]
       return existing if existing
 
       name = "Deferred#{@deferred_names.size + 1}"
-      @deferred_names[node] = name
-      @defs[name] = visit(node.type)
+      @deferred_names[target] = name
+      @defs[name] = visit(target)
       name
     end
 

--- a/lib/plumb/subtyping.rb
+++ b/lib/plumb/subtyping.rb
@@ -30,11 +30,42 @@ module Plumb
       b = Composable.wrap(b)
 
       return true if a.equal?(b) || a == b
+
+      # A Deferred stands in for the type it lazily materializes (via #type). We
+      # unwrap it here so the rest of the algebra never sees a Deferred. Recursive
+      # (self-referential) types would otherwise loop forever, so we break cycles
+      # coinductively: keyed by the identity of the (a, b) PAIR — the same Deferred
+      # may be compared against different RHSs on sibling branches, so a single-node
+      # marker would give false positives. Re-encountering a pair mid-recursion
+      # means we've closed a loop in a self-referential type: assume it holds (the
+      # greatest fixpoint) and let the surrounding structure confirm or refute it.
+      #
+      # `seen` is fiber-local (Thread.current[] is fiber-local in Ruby, not
+      # thread-local): a subtype? query never yields, so its recursion owns the set
+      # for its whole run, and concurrent fibers each get an isolated one. The
+      # ensure-delete unwinds each pair, so the set is empty again between queries.
+      if a.is_a?(Deferred) || b.is_a?(Deferred)
+        seen = (Thread.current[:plumb_subtype_seen] ||= Set.new)
+        key = [a.object_id, b.object_id]
+        return true if seen.include?(key)
+
+        seen.add(key)
+        begin
+          a = a.type if a.is_a?(Deferred)
+          b = b.type if b.is_a?(Deferred)
+          return subtype?(a, b)
+        ensure
+          seen.delete(key)
+        end
+      end
+
       return true if b.is_a?(AnyClass)  # X <= Top
       return false if a.is_a?(AnyClass) # Top <= X only when X is Top (handled above)
 
       # A Transform changes the value, so its identity for subtyping is what it
       # *produces* — its output_type. Input constraints don't carry through.
+      # TODO: do we need to pin this to Transform?
+      # why not to any type where #value_preserving? == false ?
       return subtype?(a.output_type, b) if a.is_a?(Transform)
       return subtype?(a, b.output_type) if b.is_a?(Transform)
 

--- a/lib/plumb/subtyping.rb
+++ b/lib/plumb/subtyping.rb
@@ -62,12 +62,22 @@ module Plumb
       return true if b.is_a?(AnyClass)  # X <= Top
       return false if a.is_a?(AnyClass) # Top <= X only when X is Top (handled above)
 
-      # A Transform changes the value, so its identity for subtyping is what it
-      # *produces* — its output_type. Input constraints don't carry through.
-      # TODO: do we need to pin this to Transform?
-      # why not to any type where #value_preserving? == false ?
-      return subtype?(a.output_type, b) if a.is_a?(Transform)
-      return subtype?(a, b.output_type) if b.is_a?(Transform)
+      # A value-converting type (Transform, or any custom type that opts in) is
+      # identified for subtyping by what it *produces*, not what it consumes, so we
+      # reduce `a <= b` to `produced(a) <= b` before consulting the leaf hooks. A
+      # type declares its produced identity via #subtype_identity (default: self).
+      #
+      # The `!equal?` guard is the safety rail: we only reduce when the projection
+      # is a DISTINCT node. This makes the "distinct output type" invariant
+      # structural rather than a convention — a type that projects to itself (the
+      # default, and value-preserving types like FilteredHashMap/Static) simply
+      # doesn't reduce and falls through to its #subtype_of? leaf, instead of
+      # recursing into subtype?(self, b) forever.
+      ai = a.subtype_identity
+      return subtype?(ai, b) unless ai.equal?(a)
+
+      bi = b.subtype_identity
+      return subtype?(a, bi) unless bi.equal?(b)
 
       # Unions
       return a.children.all? { |m| subtype?(m, b) } if a.is_a?(Or) # (A|B) <= C

--- a/lib/plumb/transform.rb
+++ b/lib/plumb/transform.rb
@@ -31,6 +31,10 @@ module Plumb
     def call(result)
       result.map(@input_type).map(@transform_proc).map(@output_type)
     end
+
+    # A Transform's subtyping identity is what it produces — its declared,
+    # distinct output_type. See Plumb::Subtyping.subtype? and Composable#subtype_identity.
+    def subtype_identity = @output_type
   end
 
   # A Transform whose proc is known *at build time* to produce a value of

--- a/spec/json_schema_visitor_spec.rb
+++ b/spec/json_schema_visitor_spec.rb
@@ -85,6 +85,9 @@ RSpec.describe Plumb::JSONSchemaVisitor do
     })
   end
 
+  # Two distinct `defer { list }` wrappers (the root and the one inside `next`)
+  # resolve to the SAME `list` type, so they share a single $defs entry rather
+  # than producing identical Deferred1/Deferred2 copies.
   specify '#defer at the document root references itself; envelope + $defs via .call' do
     list = nil
     list = Types::Hash[
@@ -101,20 +104,31 @@ RSpec.describe Plumb::JSONSchemaVisitor do
           'type' => 'object',
           'properties' => {
             'value' => { 'type' => 'integer' },
-            'next' => { 'anyOf' => [{ '$ref' => '#/$defs/Deferred2' }, { 'type' => 'null' }] }
-          },
-          'required' => %w[value]
-        },
-        'Deferred2' => {
-          'type' => 'object',
-          'properties' => {
-            'value' => { 'type' => 'integer' },
-            'next' => { 'anyOf' => [{ '$ref' => '#/$defs/Deferred2' }, { 'type' => 'null' }] }
+            'next' => { 'anyOf' => [{ '$ref' => '#/$defs/Deferred1' }, { 'type' => 'null' }] }
           },
           'required' => %w[value]
         }
       }
     })
+  end
+
+  # Distinct Deferreds resolving to distinct (even if structurally equal) targets
+  # keep separate defs — dedup is by target IDENTITY, not structural equality.
+  specify '#defer dedups by resolved-target identity, not structure' do
+    shared = Types::Hash[id: Types::Integer]
+    type = Types::Hash[
+      a: Types::Any.defer { shared },
+      b: Types::Any.defer { shared },              # same object as a's target -> shared def
+      c: Types::Any.defer { Types::Hash[id: Types::Integer] } # distinct object -> own def
+    ]
+
+    schema = type.to_json_schema
+    expect(schema['properties']).to eq({
+      'a' => { '$ref' => '#/$defs/Deferred1' },
+      'b' => { '$ref' => '#/$defs/Deferred1' },
+      'c' => { '$ref' => '#/$defs/Deferred2' }
+    })
+    expect(schema['$defs'].keys).to eq(%w[Deferred1 Deferred2])
   end
 
   specify 'Hash with key and value types (Hash Map)' do

--- a/spec/json_schema_visitor_spec.rb
+++ b/spec/json_schema_visitor_spec.rb
@@ -49,17 +49,71 @@ RSpec.describe Plumb::JSONSchemaVisitor do
     )
   end
 
-  specify '#defer' do
+  specify '#defer (self-referential): $ref into a hoisted $defs table' do
     type = Types::Hash[
       # String keys are converted to symbols, existing symbols are preserved
       (Types::Symbol | Types::String.transform(::Symbol, &:to_sym)),
       # Hash values are recursively symbolized, other types pass through unchanged
       Types::Any.defer { type } | Types::Any
     ]
-    schema = type.to_json_schema 
+    schema = type.to_json_schema
     expect(schema).to eq({
       'type' => 'object',
-      'patternProperties' => {'.*' => {'anyOf' => []}}
+      'patternProperties' => { '.*' => { '$ref' => '#/$defs/Deferred1' } },
+      '$defs' => {
+        'Deferred1' => {
+          'type' => 'object',
+          'patternProperties' => { '.*' => { '$ref' => '#/$defs/Deferred1' } }
+        }
+      }
+    })
+  end
+
+  specify '#defer (non-recursive): inlines the materialized type as its own $def' do
+    type = Types::Hash[
+      name: Types::String,
+      age: Types::Any.defer { Types::Integer }
+    ]
+    expect(type.to_json_schema).to eq({
+      'type' => 'object',
+      'properties' => {
+        'name' => { 'type' => 'string' },
+        'age' => { '$ref' => '#/$defs/Deferred1' }
+      },
+      'required' => %w[name age],
+      '$defs' => { 'Deferred1' => { 'type' => 'integer' } }
+    })
+  end
+
+  specify '#defer at the document root references itself; envelope + $defs via .call' do
+    list = nil
+    list = Types::Hash[
+      value: Types::Integer,
+      next?: Types::Any.defer { list } | Types::Nil
+    ]
+    root = Types::Any.defer { list }
+
+    expect(described_class.call(root)).to eq({
+      '$schema' => 'https://json-schema.org/draft-08/schema#',
+      '$ref' => '#/$defs/Deferred1',
+      '$defs' => {
+        'Deferred1' => {
+          'type' => 'object',
+          'properties' => {
+            'value' => { 'type' => 'integer' },
+            'next' => { 'anyOf' => [{ '$ref' => '#/$defs/Deferred2' }, { 'type' => 'null' }] }
+          },
+          'required' => %w[value]
+        },
+        'Deferred2' => {
+          'type' => 'object',
+          'properties' => {
+            'value' => { 'type' => 'integer' },
+            'next' => { 'anyOf' => [{ '$ref' => '#/$defs/Deferred2' }, { 'type' => 'null' }] }
+          },
+          'required' => %w[value]
+        }
+      }
     })
   end
 

--- a/spec/type_subtyping_spec.rb
+++ b/spec/type_subtyping_spec.rb
@@ -444,4 +444,48 @@ RSpec.describe 'subtyping: Plumb::Subtyping.subtype? and #<=' do
       expect(Plumb::Subtyping.subtype?(5, STypes::String)).to be(false)
     end
   end
+
+  describe 'Deferred' do
+    it 'unwraps a non-recursive Deferred to its materialized type on either side' do
+      deferred_int = STypes::Any.defer { STypes::Integer }
+      expect(deferred_int <= STypes::Numeric).to be(true)
+      expect(STypes::Integer <= deferred_int).to be(true)
+      expect(deferred_int <= STypes::String).to be(false)
+      # Deferred on both sides
+      expect(deferred_int <= STypes::Any.defer { STypes::Numeric }).to be(true)
+    end
+
+    # Two distinct but structurally identical self-referential definitions: the
+    # recursion re-encounters the same Deferred pair and must terminate rather
+    # than materialize forever.
+    it 'compares self-referential (recursive) types without looping' do
+      list_a = nil
+      list_a = STypes::Hash[value: STypes::Integer, next: STypes::Any.defer { list_a } | STypes::Nil]
+      list_b = nil
+      list_b = STypes::Hash[value: STypes::Integer, next: STypes::Any.defer { list_b } | STypes::Nil]
+
+      expect(list_a <= list_b).to be(true)
+      expect(list_b <= list_a).to be(true)
+    end
+
+    it 'is covariant through the recursive field' do
+      ints = nil
+      ints = STypes::Hash[value: STypes::Integer, next: STypes::Any.defer { ints } | STypes::Nil]
+      nums = nil
+      nums = STypes::Hash[value: STypes::Numeric, next: STypes::Any.defer { nums } | STypes::Nil]
+
+      expect(ints <= nums).to be(true)  # Integer <= Numeric, recursively
+      expect(nums <= ints).to be(false) # Numeric </= Integer
+    end
+
+    it 'leaves no leftover cycle state between independent queries' do
+      list = nil
+      list = STypes::Hash[value: STypes::Integer, next: STypes::Any.defer { list } | STypes::Nil]
+
+      expect(list <= list).to be(true)
+      # a subsequent, unrelated query on the same fiber must be unaffected
+      expect(STypes::String <= STypes::Integer).to be(false)
+      expect(Thread.current[:plumb_subtype_seen]).to satisfy { |s| s.nil? || s.empty? }
+    end
+  end
 end

--- a/spec/type_subtyping_spec.rb
+++ b/spec/type_subtyping_spec.rb
@@ -488,4 +488,49 @@ RSpec.describe 'subtyping: Plumb::Subtyping.subtype? and #<=' do
       expect(Thread.current[:plumb_subtype_seen]).to satisfy { |s| s.nil? || s.empty? }
     end
   end
+
+  describe '#subtype_identity (custom transforming types)' do
+    # A value-converting type built WITHOUT subclassing Transform. It opts into
+    # the "identified by what I produce" rule purely via #subtype_identity.
+    class RoundToInt
+      include Plumb::Composable
+
+      def initialize(output_type)
+        @output_type = Plumb::Composable.wrap(output_type)
+        freeze
+      end
+
+      def call(result) = result.valid(result.value.round)
+      def output_type = @output_type
+      def subtype_identity = @output_type
+      def value_preserving? = false
+    end
+
+    it 'is identified by its produced type on either side of the relation' do
+      to_int = RoundToInt.new(STypes::Integer)
+
+      expect(to_int <= STypes::Numeric).to be(true)  # produces Integer <= Numeric
+      expect(to_int <= STypes::String).to be(false)
+      expect(STypes::Integer <= to_int).to be(true)  # Integer <= produced Integer
+      # projects the same way a Transform does
+      expect(to_int <= STypes::Integer.transform(STypes::Numeric) { |r| r }).to be(true)
+    end
+
+    # The safety rail: a value-converting type whose #subtype_identity is left as
+    # the default (self) must NOT loop — it just falls through to its leaf hook.
+    class SelfishStep
+      include Plumb::Composable
+
+      def call(result) = result
+      def value_preserving? = false
+      # inherits Composable#subtype_identity => self
+    end
+
+    it 'does not recurse when subtype_identity returns self' do
+      selfish = SelfishStep.new
+
+      expect(selfish <= STypes::Integer).to be(false)
+      expect(selfish <= selfish).to be(true) # reflexive, via equal?
+    end
+  end
 end


### PR DESCRIPTION
## Summary

Makes `Plumb::Deferred` (lazy/recursive type references) a first-class participant in **subtyping** and **JSON Schema generation**, including self-referential types. Also generalizes the "identify a type by what it produces" rule into a public extension point.

## Subtyping for Deferred (incl. recursive types)

`Plumb::Subtyping.subtype?` now unwraps a `Deferred` to the type it lazily materializes before running the rest of the algebra, so a `Deferred` (or a whole recursive schema built from `defer { … }`) can appear on either side of `#<=` / `#>>`.

Recursion is handled **coinductively**: cycles are broken by memoizing the `(a, b)` pair identity — re-encountering a pair mid-recursion means a loop has closed in a self-referential type, so we assume it holds (greatest fixpoint) and let the surrounding structure confirm or refute. The `seen` set is fiber-local and unwound via `ensure`, so it's isolated per query and empty between queries.

To support unwrapping, `Deferred#type` (the memoized, resolved target) is now public (was `private cached_type`).

## `#subtype_identity` — a public extension point

The old special-case "a `Transform`'s subtyping identity is its `output_type`" is generalized into `Composable#subtype_identity` (default: `self`). `subtype?` reduces `a <= b` to `produced(a) <= b` whenever a type projects onto a **distinct** node:

- `Transform#subtype_identity => output_type` (unchanged behaviour).
- Any custom value-converting type can now opt into produced-identity subtyping **without subclassing `Transform`**.
- An `!equal?(self)` guard makes the "distinct output type" invariant structural: a type that projects to itself simply falls through to its `#subtype_of?` leaf instead of recursing forever.

## JSON Schema for Deferred via `$ref` / `$defs`

A `Deferred` previously emitted an empty schema (inlining would infinite-loop on self-reference). It now becomes a named `$defs` entry referenced by `$ref` — the standard JSON Schema idiom for recursion:

- Each Deferred registers its resolved target under a stable `Deferred<N>` name, keyed by the **resolved target's** identity, so distinct `defer { … }` wrappers around the same type **share one def** (dedup).
- The name is recorded *before* the body is visited, so a self-reference finds the name already present and emits a `$ref` rather than recursing.
- `.call` hoists the accumulated `$defs` table to the document root so the root-relative `#/$defs/...` pointers resolve.

## Tests

- `spec/type_subtyping_spec.rb`: Deferred subtyping, including recursive/self-referential types.
- `spec/json_schema_visitor_spec.rb`: `$ref`/`$defs` emission, recursion, and dedup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
