### PR TITLE
Plumb::Function

### DIFF
--- a/README.md
+++ b/README.md
@@ -442,9 +442,11 @@ Types::Integer.transform(:to_sym) # raises Plumb::TypeError (Integer has no #to_
 Types::Any.transform(:to_i)       # ok — unknown input type, no check
 ```
 
+`#transform` builds on an existing type. To declare the same input-to-output conversion standalone, from a callable, see [`Plumb::Transform[]`](#plumbtransforminput--output).
+
 #### `#invoke`
 
-`#invoke` builds a Step that will invoke one or more methods on the value.
+`#invoke` builds a step that will invoke one or more methods on the value.
 
 ```ruby
 StringToInt = Types::String.invoke(:to_i)
@@ -1873,25 +1875,62 @@ The `Result::Valid` class has helper methods `#valid(value) => Result::Valid` an
 
 #### Compose procs or lambdas directly
 
-Piping any `#call` object onto Plumb types will wrap your object in a `Plumb::Step` with all methods necessary for further composition.
+Piping any `#call` object onto Plumb types wraps your object in a composable step, with all methods necessary for further composition.
 
 ```ruby
 Greeting = Types::String >> ->(result) { result.valid("Hello #{result.value}") }
 ```
 
-#### Wrap a `#call` object in `Plumb::Step` explicitely
+#### `Plumb::Transform[input => output]`
 
-You can also wrap a proc in `Plumb::Step` explicitly.
+To build a standalone, typed function from a callable — one not already piped onto a type — use `Plumb::Transform[]`. Declaring both ends gives you a typed function: the input is validated before your callable runs, and the value it produces is validated against the output type.
 
 ```ruby
-Greeting = Plumb::Step.new do |result|
+Greeting = Plumb::Transform[String => String] do |result|
+  result.valid("Hello #{result.value}")
+end
+
+Greeting.parse('Joe') # => 'Hello Joe'
+Greeting.parse(10)    # raises Plumb::ParseError ("Must be a String")
+```
+
+The block takes and returns a [`Result`](#custom-types) — unlike [`#transform`](#transform), whose block takes and returns a plain value. A callable can be passed instead of a block:
+
+```ruby
+Greeting = Plumb::Transform[MyGreeter.new, String => String]
+```
+
+Because both ends are declared, the resulting step takes part in [composition type checks](#composition-type-checks) and JSON Schema generation, just like `#transform`:
+
+```ruby
+StringLength = Plumb::Transform[String => Integer] { |result| result.valid(result.value.size) }
+StringLength.input_type  # => String
+StringLength.output_type # => Integer
+
+Types::Integer >> StringLength # raises Plumb::TypeError at build time
+```
+
+You can also pass a custom `#call(Result) => Result` interface as the first argument, to turn a callable into a typed function.
+
+```ruby
+TypedGreeting = Plumb::Transform[Greeting.new('Mr.'), String => String]
+TypedGreeting.parse('Joe') # "Mr. Joe"
+TypedGreeting.parse(10) # raises Plumb::ParseError
+```
+
+
+
+Omit the types when the callable is genuinely untyped. Both ends default to `Types::Any`, and the step opts out of composition checks.
+
+```ruby
+Greeting = Plumb::Transform[] do |result|
   result.valid("Hello #{result.value}")
 end
 ```
 
-Note that this example is not prefixed by `Types::String`, so it doesn't first validate that the input is indeed a string.
+Note that this last example doesn't validate that the input is indeed a String, whereas `Plumb::Transform[String => String]` does.
 
-However, this means that `Greeting` is a `Plumb::Step` which comes with all the Plumb methods and policies.
+Either way, `Greeting` is a full Plumb step, which comes with all the Plumb methods and policies.
 
 ```ruby
 # Greeting responds to #>>, #|, #default, #transform, etc etc
@@ -1908,11 +1947,11 @@ class Greeting
     @gr = gr
   end
 
-  # The Plumb Step interface
+  # The Plumb step interface
   # @param result [Plumb::Result::Valid]
   # @return [Plumb::Result::Valid, Plumb::Result::Invalid]
   def call(result)
-    result.valid("#{gr} #{result.value}")
+    result.valid("#{@gr} #{result.value}")
   end
 end
 
@@ -1923,7 +1962,7 @@ This is useful when you want to parameterize your custom steps, for example by i
 
 #### Include `Plumb::Composable` to make instance of a class full "steps"
 
-The class above will be wrapped by `Plumb::Step` when piped into other steps, but it doesn't support Plumb methods on its own.
+The class above will be wrapped in a composable step when piped into other steps, but it doesn't support Plumb methods on its own.
 
 Including `Plumb::Composable` makes it support all Plumb methods directly.
 
@@ -1937,7 +1976,7 @@ class Greeting
     @gr = gr
   end
   
-  # The Step interface
+  # The step interface
   def call(result)
     result.valid("#{gr} #{result.value}")
   end

--- a/README.md
+++ b/README.md
@@ -442,7 +442,7 @@ Types::Integer.transform(:to_sym) # raises Plumb::TypeError (Integer has no #to_
 Types::Any.transform(:to_i)       # ok — unknown input type, no check
 ```
 
-`#transform` builds on an existing type. To declare the same input-to-output conversion standalone, from a callable, see [`Plumb::Transform[]`](#plumbtransforminput--output).
+`#transform` builds a [`Plumb::Function`](#plumbfunctioninput--output) — the underlying typed-conversion node — with a block that takes and returns a plain value. To build one standalone from a callable, or to work at the `Result` level, use `Plumb::Function[]` directly.
 
 #### `#invoke`
 
@@ -1881,12 +1881,12 @@ Piping any `#call` object onto Plumb types wraps your object in a composable ste
 Greeting = Types::String >> ->(result) { result.valid("Hello #{result.value}") }
 ```
 
-#### `Plumb::Transform[input => output]`
+#### `Plumb::Function[input => output]`
 
-To build a standalone, typed function from a callable — one not already piped onto a type — use `Plumb::Transform[]`. Declaring both ends gives you a typed function: the input is validated before your callable runs, and the value it produces is validated against the output type.
+To build a standalone, typed function from a callable — one not already piped onto a type — use `Plumb::Function[]`. Declaring both ends gives you a typed function: the input is validated before your callable runs, and the value it produces is validated against the output type.
 
 ```ruby
-Greeting = Plumb::Transform[String => String] do |result|
+Greeting = Plumb::Function[String => String] do |result|
   result.valid("Hello #{result.value}")
 end
 
@@ -1897,13 +1897,13 @@ Greeting.parse(10)    # raises Plumb::ParseError ("Must be a String")
 The block takes and returns a [`Result`](#custom-types) — unlike [`#transform`](#transform), whose block takes and returns a plain value. A callable can be passed instead of a block:
 
 ```ruby
-Greeting = Plumb::Transform[MyGreeter.new, String => String]
+Greeting = Plumb::Function[MyGreeter.new, String => String]
 ```
 
 Because both ends are declared, the resulting step takes part in [composition type checks](#composition-type-checks) and JSON Schema generation, just like `#transform`:
 
 ```ruby
-StringLength = Plumb::Transform[String => Integer] { |result| result.valid(result.value.size) }
+StringLength = Plumb::Function[String => Integer] { |result| result.valid(result.value.size) }
 StringLength.input_type  # => String
 StringLength.output_type # => Integer
 
@@ -1913,7 +1913,7 @@ Types::Integer >> StringLength # raises Plumb::TypeError at build time
 You can also pass a custom `#call(Result) => Result` interface as the first argument, to turn a callable into a typed function.
 
 ```ruby
-TypedGreeting = Plumb::Transform[Greeting.new('Mr.'), String => String]
+TypedGreeting = Plumb::Function[Greeting.new('Mr.'), String => String]
 TypedGreeting.parse('Joe') # "Mr. Joe"
 TypedGreeting.parse(10) # raises Plumb::ParseError
 ```
@@ -1923,12 +1923,12 @@ TypedGreeting.parse(10) # raises Plumb::ParseError
 Omit the types when the callable is genuinely untyped. Both ends default to `Types::Any`, and the step opts out of composition checks.
 
 ```ruby
-Greeting = Plumb::Transform[] do |result|
+Greeting = Plumb::Function[] do |result|
   result.valid("Hello #{result.value}")
 end
 ```
 
-Note that this last example doesn't validate that the input is indeed a String, whereas `Plumb::Transform[String => String]` does.
+Note that this last example doesn't validate that the input is indeed a String, whereas `Plumb::Function[String => String]` does.
 
 Either way, `Greeting` is a full Plumb step, which comes with all the Plumb methods and policies.
 
@@ -2051,7 +2051,7 @@ even <= Types::String    # => false
 
 The `#>>` check (and the [JSON Schema visitor](#json-schema)) ask what a type accepts and produces; both [default to `self`](#input_type-and-output_type). Override them when your type changes the value or is opaque about it:
 
-- a value-converting step declares a different `#output_type` (what `#transform`/`#build` do via `Plumb::Transform`);
+- a value-converting step declares a different `#output_type` (what `#transform`/`#build` do via `Plumb::Function`);
 - an opaque step (a wrapped proc, a generator) returns `Types::Any` for both, opting out of the `#>>` compatibility check.
 
 Custom types are **values/leaves** in the algebra — you compose them with the built-in combinators (`#>>`, `#|`, `#transform`, `Types::Any`) rather than re-implementing those.

--- a/README.md
+++ b/README.md
@@ -658,12 +658,21 @@ TODO: document custom visitors.
 
 #### `#input_type` and `#output_type`
 
-Every type exposes the type it expects as input and the type it produces as output. For a sequence `A >> B`, the input type is `A` and the output type is `B`.
+Every type exposes the type it expects as input and the type it produces as output.
 
 ```ruby
 StringToInt = Types::String.transform(Integer, &:to_i)
 StringToInt.input_type  # Types::String
 StringToInt.output_type # Integer
+```
+
+They resolve through a composition, reporting what the chain as a whole consumes and produces — not its individual steps. The steps themselves remain available as `#children`:
+
+```ruby
+chain = Types::String.transform(Integer, &:to_i) >> Types::Integer.transform(Integer) { |i| i * 2 }
+chain.input_type  # Types::String — the chain can only be called with a String
+chain.output_type # Integer       — it can only produce an Integer
+chain.children    # [(Types::String -> Integer), (Types::Integer -> Integer)]
 ```
 
 For a plain type, both are the type itself. Unions distribute over both sides:

--- a/lib/plumb.rb
+++ b/lib/plumb.rb
@@ -71,7 +71,7 @@ module Plumb
     case node.node_name
     when :or
       node.children.flat_map { |child| resolve_base_types(child) }
-    when :and, :transform
+    when :and, :function
       resolve_base_types(node.output_type)
     when :constraint
       # A refinement matcher carries its base type — resolve that (eg.
@@ -108,7 +108,7 @@ require 'plumb/any_class'
 require 'plumb/never_class'
 require 'plumb/step'
 require 'plumb/and'
-require 'plumb/transform'
+require 'plumb/function'
 require 'plumb/pipeline'
 require 'plumb/static_class'
 require 'plumb/value_class'

--- a/lib/plumb/and.rb
+++ b/lib/plumb/and.rb
@@ -11,8 +11,8 @@ module Plumb
     # A refinement/sequencing join, built by `Composable#>>`. Both sides
     # validate the *same* value (no conversion), so an `And` is the
     # intersection of its children: the longer the chain, the narrower the
-    # type. A value-converting step is a `Transform` instead (see
-    # lib/plumb/transform.rb).
+    # type. A value-converting step is a `Function` instead (see
+    # lib/plumb/function.rb).
     def initialize(left, right)
       @input_type = left
       @output_type = right

--- a/lib/plumb/and.rb
+++ b/lib/plumb/and.rb
@@ -13,25 +13,35 @@ module Plumb
     # intersection of its children: the longer the chain, the narrower the
     # type. A value-converting step is a `Function` instead (see
     # lib/plumb/function.rb).
+    #
+    # #input_type / #output_type are the types the chain as a whole CONSUMES and
+    # PRODUCES — not its two sides (those are `children`). They resolve through
+    # the chain: `(String -> Integer) >> (Integer -> Integer)` consumes String
+    # and produces Integer, not its left and right steps. Resolving one hop at
+    # construction is enough — the children are already resolved by the same
+    # rule, so this is O(1) per node — and doing it here (rather than through
+    # Subtyping.resolved_*) keeps it off the memoization path entirely.
     def initialize(left, right)
-      @input_type = left
-      @output_type = right
+      @left = left
+      @right = right
+      @input_type = left.input_type
+      @output_type = right.output_type
       @children = [left, right].freeze
       freeze
     end
 
     private def _inspect
-      %((#{@input_type.inspect} >> #{@output_type.inspect}))
+      %((#{@left.inspect} >> #{@right.inspect}))
     end
 
     def call(result)
-      result.map(@input_type).map(@output_type)
+      result.map(@left).map(@right)
     end
 
     # As a consumer a refinement accepts the constraint it actually passes — its
-    # resolved output — not its #input_type, which is only the base (left) type
-    # and would ignore the refinement (eg. `Integer[1..10].input_type` is just
-    # Integer, but it only accepts values in 1..10).
+    # resolved output — not its #input_type, which is only the type the chain
+    # opens with and would ignore the refinement (eg. `Integer[1..10].input_type`
+    # is just Integer, but it only accepts values in 1..10).
     def accepted_type = Plumb::Subtyping.resolved_output(self)
 
     # A conjunction preserves the value only if BOTH steps do — a transform on

--- a/lib/plumb/composable.rb
+++ b/lib/plumb/composable.rb
@@ -262,8 +262,8 @@ module Plumb
     # takes as input (its resolved #input_type): right for plain matchers and for
     # conversion/consumer types (Function, Stream, Pipeline — they accept their
     # declared input, so they need no override). Two kinds of type override it:
-    #   - a refinement (And): its #input_type is only the base (left) type and
-    #     would drop the constraint it adds, so it accepts its resolved *output*;
+    #   - a refinement (And): its #input_type is only the type the chain opens
+    #     with and would drop the constraint it adds, so it accepts its *output*;
     #   - a Hash: it relaxes each field to what that field accepts.
     # Consulted by Plumb::Subtyping when checking `#>>`.
     def accepted_type = Plumb::Subtyping.resolved_input(self)

--- a/lib/plumb/composable.rb
+++ b/lib/plumb/composable.rb
@@ -141,7 +141,7 @@ module Plumb
     def >(other) = (self >= other) && !(self <= other)
 
     # Leaf hook for Plumb::Subtyping.subtype?, called once the algebra (And/Or/
-    # Transform/top) has been peeled away. It must NOT delegate back to #<= (that
+    # Function/top) has been peeled away. It must NOT delegate back to #<= (that
     # would recurse); it recurses only through Plumb::Subtyping.subtype?.
     #
     # Default behaviour:
@@ -246,7 +246,7 @@ module Plumb
     # The type that carries this node's identity for the subtype relation. A
     # value-preserving type IS its own identity (the default). A value-converting
     # type is identified by what it *produces*, so it projects onto a DISTINCT
-    # type (see Transform#subtype_identity => output_type): Plumb::Subtyping.subtype?
+    # type (see Function#subtype_identity => output_type): Plumb::Subtyping.subtype?
     # reduces `a <= b` to `produced(a) <= b` before consulting the leaf hooks.
     #
     # CONTRACT: only return a value other than `self` when that value is a
@@ -254,13 +254,13 @@ module Plumb
     # with `!equal?(self)`, so it simply won't reduce); returning a node whose own
     # #subtype_identity loops back would recurse forever. This is the extension
     # point for building custom transforming types that play well with subtyping
-    # WITHOUT subclassing Transform.
+    # WITHOUT subclassing Function.
     def subtype_identity = self
 
     # The type this step accepts as the consumer of a `left >> self` chain — the
     # values its #call processes without rejecting outright. Defaults to what it
     # takes as input (its resolved #input_type): right for plain matchers and for
-    # conversion/consumer types (Transform, Stream, Pipeline — they accept their
+    # conversion/consumer types (Function, Stream, Pipeline — they accept their
     # declared input, so they need no override). Two kinds of type override it:
     #   - a refinement (And): its #input_type is only the base (left) type and
     #     would drop the constraint it adds, so it accepts its resolved *output*;
@@ -343,7 +343,7 @@ module Plumb
     # Chain two composable objects together as a disjunction ("or").
     # When one value-preserving branch subsumes the other (`Integer | Numeric`,
     # or `X | X`), the union absorbs to the wider branch — see
-    # Subtyping.reduce_union. Transforms/containers never reduce (they may accept
+    # Subtyping.reduce_union. Functions/containers never reduce (they may accept
     # inputs the survivor rejects), so coercion unions are preserved.
     #
     # @param other [Composable]
@@ -389,7 +389,7 @@ module Plumb
     # @param target_type [Class, Symbol] the output type, or a conversion symbol
     # @param callable [#call, nil] a callable that will be applied to the value, or nil if block provided
     # @param block [Proc] a block that will be applied to the value, or nil if callable provided
-    # @return [Transform]
+    # @return [Function]
     def transform(target_type, callable = nil, &block)
       if target_type.is_a?(::Symbol) && callable.nil? && block.nil? && (out = COERCION_METHODS[target_type])
         return coercion_transform(target_type, out)
@@ -662,10 +662,10 @@ module Plumb
       transform_step(cns, block || ->(value) { cns.send(factory_method, value) })
     end
 
-    # Build a Transform that validates the input (self), applies a value-level
+    # Build a Function that validates the input (self), applies a value-level
     # callable, and declares `target_type` as the (validated) output type.
     private def transform_step(target_type, callable, guaranteed: false)
-      klass = guaranteed ? GuaranteedTransform : Transform
+      klass = guaranteed ? GuaranteedFunction : Function
       # Flip the cursor in place with the transformed value — the transform owns
       # the result it is handed (the argument is evaluated first, reading the
       # pre-transform value), so no fresh Result is needed.

--- a/lib/plumb/decorator.rb
+++ b/lib/plumb/decorator.rb
@@ -28,10 +28,10 @@ module Plumb
              when And
                left, right = visit_children(type)
                And.new(left, right)
-             when Transform
+             when Function
                left, right = visit_children(type)
-               # type.class preserves a GuaranteedTransform across decoration.
-               type.class.new(left, right, type.transform_proc)
+               # type.class preserves a GuaranteedFunction across decoration.
+               type.class.new(left, right, type.fn)
              when Or
                left, right = visit_children(type)
                Or.new(left, right)

--- a/lib/plumb/function.rb
+++ b/lib/plumb/function.rb
@@ -4,19 +4,19 @@ require 'plumb/composable'
 
 module Plumb
   # A value-converting join, built by `Composable#transform` / `#build`.
-  # Unlike `And` (a refinement), a `Transform` changes the value: it validates
-  # the input (`input_type`), applies `transform`, then declares `output_type`
+  # Unlike `And` (a refinement), a `Function` changes the value: it validates
+  # the input (`input_type`), applies `fn`, then declares `output_type`
   # as the produced type. The input constraints do NOT carry through to the
-  # output, so for subtyping a `Transform` is identified by what it *produces*
+  # output, so for subtyping a `Function` is identified by what it *produces*
   # (its `output_type`). See Plumb::Subtyping.subtype?.
-  class Transform
+  class Function
     include Composable
 
-    # Build a typed function (a Transform) from an input => output pair and a
+    # Build a typed function from an input => output pair and a
     # callable that produces the new value.
     #
-    #   Plumb::Transform[String => Integer] { |result| result.valid(result.value.size) }
-    #   Plumb::Transform[callable, String => Integer]
+    #   Plumb::Function[String => Integer] { |result| result.valid(result.value.size) }
+    #   Plumb::Function[callable, String => Integer]
     #
     # The callable takes and returns a Result (unlike Composable#transform, whose
     # block takes a value). With no types, both ends default to Types::Any.
@@ -29,7 +29,7 @@ module Plumb
     def self.[](*args, &block)
       input_type = Types::Any
       output_type = Types::Any
-      transform = block || NOOP
+      fn = block || NOOP
 
       case args
       in []
@@ -37,30 +37,30 @@ module Plumb
       in [clb, Hash => inout] if clb.respond_to?(:call)
         raise ArgumentError, 'expected a callable or a block, not both' if block
 
-        transform = clb
+        fn = clb
         input_type, output_type = __set_types(inout)
       in [clb] if clb.respond_to?(:call)
         raise ArgumentError, 'expected a callable or a block, not both' if block
 
-        transform = clb
+        fn = clb
       in [Hash => inout]
         input_type, output_type = __set_types(inout)
       else
         raise ArgumentError,
-              'expected Plumb::Transform[input_type => output_type], Plumb::Transform[callable] ' \
-              "or Plumb::Transform[callable, input_type => output_type]. Got #{args.inspect}"
+              'expected Plumb::Function[input_type => output_type], Plumb::Function[callable] ' \
+              "or Plumb::Function[callable, input_type => output_type]. Got #{args.inspect}"
       end
 
-      return input_type if input_type == output_type && transform == NOOP
+      return input_type if input_type == output_type && fn == NOOP
 
-      if transform == NOOP
+      if fn == NOOP
         raise ArgumentError,
               "defined a function (#{input_type} -> #{output_type}), but no explicit " \
               "transform block or callable given. \n" \
-              "Should be Plumb::Transform[#{input_type} => #{output_type}] { |r| r.valid(new_value_here) }"
+              "Should be Plumb::Function[#{input_type} => #{output_type}] { |r| r.valid(new_value_here) }"
       end
 
-      new(input_type, output_type, transform)
+      new(input_type, output_type, fn)
     end
 
     def self.__set_types(inout)
@@ -73,14 +73,14 @@ module Plumb
     end
     private_class_method :__set_types
 
-    # `transform_proc` (not `transform`, which is Composable's builder method)
-    # exposes the value-level callable so the Decorator can rebuild the node.
-    attr_reader :children, :input_type, :output_type, :transform_proc
+    # `fn` is the value-level callable — `#call(Result) => Result`. Exposed so
+    # the Decorator can rebuild the node around it.
+    attr_reader :children, :input_type, :output_type, :fn
 
-    def initialize(input_type, output_type, transform_proc = Plumb::NOOP)
+    def initialize(input_type, output_type, fn = Plumb::NOOP)
       @input_type = input_type
       @output_type = output_type
-      @transform_proc = transform_proc
+      @fn = fn
       @children = [input_type, output_type].freeze
       freeze
     end
@@ -90,25 +90,25 @@ module Plumb
     end
 
     def call(result)
-      result.map(@input_type).map(@transform_proc).map(@output_type)
+      result.map(@input_type).map(@fn).map(@output_type)
     end
 
-    # A Transform's subtyping identity is what it produces — its declared,
+    # A Function's subtyping identity is what it produces — its declared,
     # distinct output_type. See Plumb::Subtyping.subtype? and Composable#subtype_identity.
     def subtype_identity = @output_type
   end
 
-  # A Transform whose proc is known *at build time* to produce a value of
+  # A Function whose proc is known *at build time* to produce a value of
   # output_type (eg. a `:to_i` coercion always yields an Integer), so the runtime
   # output check is provably redundant. Choosing the class at build time means
   # #call carries no per-call `guaranteed?` branch — the check is simply absent.
-  # It inherits Transform's node_name (:transform) and `is_a?(Transform)`, so
-  # visitors, JSON-schema, subtyping and the decorator treat it as a Transform;
+  # It inherits Function's node_name (:function) and `is_a?(Function)`, so
+  # visitors, JSON-schema, subtyping and the decorator treat it as a Function;
   # only the produced value's output re-validation is dropped. @output_type is
   # still kept as metadata (inference / JSON schema / subtyping).
-  class GuaranteedTransform < Transform
+  class GuaranteedFunction < Function
     def call(result)
-      result.map(@input_type).map(@transform_proc)
+      result.map(@input_type).map(@fn)
     end
   end
 end

--- a/lib/plumb/hash_class.rb
+++ b/lib/plumb/hash_class.rb
@@ -3,7 +3,7 @@
 require 'plumb/composable'
 require 'plumb/key'
 require 'plumb/static_class'
-require 'plumb/transform'
+require 'plumb/function'
 require 'plumb/hash_map'
 require 'plumb/tagged_hash'
 
@@ -388,16 +388,16 @@ module Plumb
     end
   end
 
-  # The typed node returned by HashClass#filtered. It is a Transform — so #>>
+  # The typed node returned by HashClass#filtered. It is a Function — so #>>
   # treats it as a conversion (subtype by its output, accepted by its input) and
   # it bypasses the strict composition check — declaring `input_type` as the
   # filtered schema and `output_type` as that schema with all keys optional. But
-  # unlike a plain Transform it does NOT strict-validate its input: #call runs
+  # unlike a plain Function it does NOT strict-validate its input: #call runs
   # the lenient filter, which accepts any Hash and drops invalid/missing/extra
   # fields.
-  class FilteredHash < Transform
-    # Naming derives #node_name when Composable is *included* (on Transform), so
-    # the subclass would otherwise inherit :transform.
+  class FilteredHash < Function
+    # Naming derives #node_name when Composable is *included* (on Function), so
+    # the subclass would otherwise inherit :function.
     def node_name = :filtered_hash
 
     # A filtered Hash is lenient: it accepts ANY hash and drops invalid/missing/
@@ -409,7 +409,7 @@ module Plumb
 
     def accepted_type = FilteredHash.each_pair_interface
 
-    def call(result) = transform_proc.call(result)
+    def call(result) = fn.call(result)
 
     private def _inspect = "#{input_type.inspect}.filtered"
   end

--- a/lib/plumb/json_schema_visitor.rb
+++ b/lib/plumb/json_schema_visitor.rb
@@ -180,9 +180,9 @@ module Plumb
     # disjunction is a *refinement* of the base, not a different type: render the
     # base, then fold the (type-less) disjunction's `anyOf` into that same spec.
     on(:refined_union) do |node, props|
-      and_node = node.type
-      props = visit(and_node.input_type, props) # base -> {type: …}
-      visit(and_node.output_type, props)        # Or(suffixes) -> merge anyOf into it
+      base, disjunction = node.type.children # the And's two sides, not its io types
+      props = visit(base, props)             # base -> {type: …}
+      visit(disjunction, props)              # Or(suffixes) -> merge anyOf into it
     end
 
     on(:and) do |node, props|

--- a/lib/plumb/json_schema_visitor.rb
+++ b/lib/plumb/json_schema_visitor.rb
@@ -196,13 +196,13 @@ module Plumb
       end
     end
 
-    # A conversion (`Transform`) produces a genuinely different value. A JSON
+    # A conversion (`Function`) produces a genuinely different value. A JSON
     # Schema describes accepted *inputs*, so it is built from the input side and
     # the output is dropped — and crucially NOT visited, so a transform whose
     # output type has no schema handler (eg. a custom class via #build) is fine.
     # Only when the input is untyped (eg. `Any.transform(::Integer)`) do we fall
     # back to the output type, since that is then all we know.
-    on(:transform) do |node, props|
+    on(:function) do |node, props|
       left = visit(node.input_type)
       return props.merge(left) if left.key?(TYPE)
 

--- a/lib/plumb/metadata_visitor.rb
+++ b/lib/plumb/metadata_visitor.rb
@@ -51,7 +51,7 @@ module Plumb
       visit(node.type, props)
     end
 
-    on(:transform) do |node, props|
+    on(:function) do |node, props|
       left, right = node.children.map { |child| visit(child) }
       props.merge(left).merge(right)
     end

--- a/lib/plumb/pipeline.rb
+++ b/lib/plumb/pipeline.rb
@@ -72,7 +72,7 @@ module Plumb
     #
     #   pl.step(type_or_callable)        # non-strict chain (via #/)
     #   pl.step!(type_or_callable)       # strict #>> chain (type-checked)
-    #   pl.step(output_type) { |r| ... } # a Transform: validates the current
+    #   pl.step(output_type) { |r| ... } # a Function: validates the current
     #                                    # output, runs the block, and declares
     #                                    # `output_type` as the produced type
     def step(callable = nil, &block)
@@ -94,11 +94,11 @@ module Plumb
     private
 
     # Shared body for #step / #step!. The `output_type` + block form always
-    # builds a Transform (a declared conversion) regardless of `strict`; the
+    # builds a Function (a declared conversion) regardless of `strict`; the
     # plain form chains with `#>>` when strict, `#/` otherwise.
     def add_step(callable, strict:, &block)
       if !callable.nil? && block
-        @type = Transform.new(@type, Composable.wrap(callable), block)
+        @type = Function.new(@type, Composable.wrap(callable), block)
         return self
       end
 

--- a/lib/plumb/subtyping.rb
+++ b/lib/plumb/subtyping.rb
@@ -546,7 +546,7 @@ module Plumb
     def steps(type)
       type = type.type if type.is_a?(Composable::Node) && type.node_name == :refined_union
       case type
-      when And then steps(type.input_type) + steps(type.output_type)
+      when And then type.children.flat_map { |c| steps(c) }
       when Constraint then type.base ? steps(type.base) + [Constraint.new(type.matcher)] : [type]
       else [type]
       end
@@ -608,12 +608,12 @@ module Plumb
       end
     end
 
-    # #output_type / #input_type are shallow (one level): an And's output_type is
-    # its right child, which may itself be an opaque Step (output Any) or another
-    # composite. Follow the chain to a fixpoint so the composition check sees the
-    # effective produced/accepted type (and so opaque steps resolve to Any).
-    # Memoized per node in TypeCache (frozen nodes only), so re-resolving a chain
-    # that was already walked — eg. each step of A >> B >> C >> D — is O(1).
+    # Every node resolves its own #input_type / #output_type (an And does it at
+    # construction, an Or maps over its branches), so this is normally a single
+    # hop. The loop remains for nodes that delegate through a wrapper chain, and
+    # bottoms out when a type is its own io type. Memoized per node in TypeCache
+    # (frozen nodes only) — worth it for Or, which allocates a fresh Or of its
+    # resolved branches on every call.
     def resolved_output(type, depth = 0)
       TypeCache.fetch(:resolved_output, type) do
         nxt = type.output_type

--- a/lib/plumb/subtyping.rb
+++ b/lib/plumb/subtyping.rb
@@ -17,7 +17,7 @@ module Plumb
     # `String` compare the same way.
     #
     # This engine knows ONLY the composition algebra — refinement (And), union
-    # (Or), conversion (Transform) and the top type (AnyClass). Everything else
+    # (Or), conversion (Function) and the top type (AnyClass). Everything else
     # (atomic matchers, covariant containers, Hash width/depth, custom types) is
     # decided by the type's own #subtype_of? leaf hook (see Composable). It never
     # calls #<= (which would recurse back here).
@@ -62,7 +62,7 @@ module Plumb
       return true if b.is_a?(AnyClass)  # X <= Top
       return false if a.is_a?(AnyClass) # Top <= X only when X is Top (handled above)
 
-      # A value-converting type (Transform, or any custom type that opts in) is
+      # A value-converting type (Function, or any custom type that opts in) is
       # identified for subtyping by what it *produces*, not what it consumes, so we
       # reduce `a <= b` to `produced(a) <= b` before consulting the leaf hooks. A
       # type declares its produced identity via #subtype_identity (default: self).
@@ -389,7 +389,7 @@ module Plumb
     # the surviving type, or nil to fall back to `Or.new`.
     #
     # Guarded to VALUE-PRESERVING refinements only. `subtype?` identifies a
-    # Transform by its OUTPUT type, so `subtype?(String->Integer, Numeric)` is
+    # Function by its OUTPUT type, so `subtype?(String->Integer, Numeric)` is
     # true even though that branch accepts Strings a bare Numeric rejects —
     # reducing there would silently drop a coercion branch. Only when both
     # branches pass values through unchanged does `subtype?` reflect the accepted
@@ -579,7 +579,7 @@ module Plumb
     # Does `type` return its input unchanged on success (a coreflexive
     # refinement)? Delegates to the type's polymorphic #value_preserving? hook —
     # so custom types opt in by defining it — and memoizes per frozen node in
-    # TypeCache, a pure structural predicate like #accepted_type. Transforms and
+    # TypeCache, a pure structural predicate like #accepted_type. Functions and
     # value-building containers (Hash/Array/Tuple/…) change the value and stay
     # false; refinements and their And/Or compositions are true.
     def value_preserving?(type)

--- a/lib/plumb/transform.rb
+++ b/lib/plumb/transform.rb
@@ -12,6 +12,67 @@ module Plumb
   class Transform
     include Composable
 
+    # Build a typed function (a Transform) from an input => output pair and a
+    # callable that produces the new value.
+    #
+    #   Plumb::Transform[String => Integer] { |result| result.valid(result.value.size) }
+    #   Plumb::Transform[callable, String => Integer]
+    #
+    # The callable takes and returns a Result (unlike Composable#transform, whose
+    # block takes a value). With no types, both ends default to Types::Any.
+    # When input and output are the same type and there's nothing to apply, this
+    # is just that type, so it's returned as-is.
+    #
+    # @param args [Array] (in => out), (callable), or (callable, in => out)
+    # @yield [Result] Result => Result
+    # @return [Composable]
+    def self.[](*args, &block)
+      input_type = Types::Any
+      output_type = Types::Any
+      transform = block || NOOP
+
+      case args
+      in []
+        # no types, no callable: defaults apply
+      in [clb, Hash => inout] if clb.respond_to?(:call)
+        raise ArgumentError, 'expected a callable or a block, not both' if block
+
+        transform = clb
+        input_type, output_type = __set_types(inout)
+      in [clb] if clb.respond_to?(:call)
+        raise ArgumentError, 'expected a callable or a block, not both' if block
+
+        transform = clb
+      in [Hash => inout]
+        input_type, output_type = __set_types(inout)
+      else
+        raise ArgumentError,
+              'expected Plumb::Transform[input_type => output_type], Plumb::Transform[callable] ' \
+              "or Plumb::Transform[callable, input_type => output_type]. Got #{args.inspect}"
+      end
+
+      return input_type if input_type == output_type && transform == NOOP
+
+      if transform == NOOP
+        raise ArgumentError,
+              "defined a function (#{input_type} -> #{output_type}), but no explicit " \
+              "transform block or callable given. \n" \
+              "Should be Plumb::Transform[#{input_type} => #{output_type}] { |r| r.valid(new_value_here) }"
+      end
+
+      new(input_type, output_type, transform)
+    end
+
+    def self.__set_types(inout)
+      return [Types::Any, Types::Any] if inout.empty?
+      raise ArgumentError, 'expected single key input_type => output_type' if inout.size > 1
+
+      input_type = Composable.wrap(inout.keys.first)
+      output_type = Composable.wrap(inout.values.first)
+      [input_type, output_type]
+    end
+    private_class_method :__set_types
+
     # `transform_proc` (not `transform`, which is Composable's builder method)
     # exposes the value-level callable so the Decorator can rebuild the node.
     attr_reader :children, :input_type, :output_type, :transform_proc

--- a/spec/function_spec.rb
+++ b/spec/function_spec.rb
@@ -2,10 +2,10 @@
 
 require 'spec_helper'
 
-RSpec.describe Plumb::Transform do
+RSpec.describe Plumb::Function do
   describe '.[]' do
     specify 'input => output with a block' do
-      type = Plumb::Transform[String => Integer] { |result| result.valid(result.value.size) }
+      type = Plumb::Function[String => Integer] { |result| result.valid(result.value.size) }
 
       expect(type).to be_a(described_class)
       expect(type.input_type).to eq(Types::String)
@@ -15,29 +15,29 @@ RSpec.describe Plumb::Transform do
 
     specify 'input => output with a callable' do
       callable = ->(result) { result.valid(result.value.size) }
-      type = Plumb::Transform[callable, String => Integer]
+      type = Plumb::Function[callable, String => Integer]
 
       expect(type).to be_a(described_class)
       assert_result(type.resolve('abc'), 3, true)
     end
 
     it 'validates both ends of the function' do
-      type = Plumb::Transform[String => Integer] { |result| result.valid(result.value.to_s) }
+      type = Plumb::Function[String => Integer] { |result| result.valid(result.value.to_s) }
 
       assert_result(type.resolve(10), 10, false)
       assert_result(type.resolve('abc'), 'abc', false)
     end
 
     it 'wraps Composable types as well as Ruby classes' do
-      type = Plumb::Transform[Types::String => Types::Integer] { |result| result.valid(result.value.size) }
+      type = Plumb::Function[Types::String => Types::Integer] { |result| result.valid(result.value.size) }
 
       assert_result(type.resolve('abcd'), 4, true)
     end
 
     it 'composes with other steps' do
       type = Types::String \
-        >> Plumb::Transform[String => Integer] { |r| r.valid(r.value.size) } \
-        >> Plumb::Transform[Integer => String] { |r| r.valid("size: #{r.value}") }
+        >> Plumb::Function[String => Integer] { |r| r.valid(r.value.size) } \
+        >> Plumb::Function[Integer => String] { |r| r.valid("size: #{r.value}") }
 
       assert_result(type.resolve('abc'), 'size: 3', true)
       assert_result(type.resolve(10), 10, false)
@@ -45,16 +45,16 @@ RSpec.describe Plumb::Transform do
 
     describe 'identity' do
       it 'returns the type itself when input and output match and there is nothing to apply' do
-        expect(Plumb::Transform[String => String]).to eq(Types::String)
+        expect(Plumb::Function[String => String]).to eq(Types::String)
       end
 
       it 'returns Types::Any with no arguments' do
-        expect(Plumb::Transform[]).to eq(Types::Any)
-        expect(Plumb::Transform[{}]).to eq(Types::Any)
+        expect(Plumb::Function[]).to eq(Types::Any)
+        expect(Plumb::Function[{}]).to eq(Types::Any)
       end
 
-      it 'still builds a Transform when a callable is given' do
-        type = Plumb::Transform[String => String] { |result| result.valid(result.value.upcase) }
+      it 'still builds a Function when a callable is given' do
+        type = Plumb::Function[String => String] { |result| result.valid(result.value.upcase) }
 
         expect(type).to be_a(described_class)
         assert_result(type.resolve('abc'), 'ABC', true)
@@ -62,7 +62,7 @@ RSpec.describe Plumb::Transform do
     end
 
     specify 'a callable with no types' do
-      type = Plumb::Transform[->(result) { result.valid(result.value * 2) }]
+      type = Plumb::Function[->(result) { result.valid(result.value * 2) }]
 
       expect(type.input_type).to eq(Types::Any)
       expect(type.output_type).to eq(Types::Any)
@@ -70,7 +70,7 @@ RSpec.describe Plumb::Transform do
     end
 
     specify 'a block with no types' do
-      type = Plumb::Transform[] { |result| result.valid(result.value * 2) }
+      type = Plumb::Function[] { |result| result.valid(result.value * 2) }
 
       assert_result(type.resolve(2), 4, true)
       assert_result(type.resolve('ab'), 'abab', true)
@@ -78,27 +78,27 @@ RSpec.describe Plumb::Transform do
 
     describe 'argument errors' do
       it 'raises when types differ but no callable is given' do
-        expect { Plumb::Transform[String => Integer] }.to raise_error(ArgumentError, /no explicit transform/)
+        expect { Plumb::Function[String => Integer] }.to raise_error(ArgumentError, /no explicit transform/)
       end
 
       it 'raises when given more than one input => output pair' do
-        expect { Plumb::Transform[{ String => Integer, Integer => String }] }
+        expect { Plumb::Function[{ String => Integer, Integer => String }] }
           .to raise_error(ArgumentError, /single key/)
       end
 
       it 'raises when given both a callable and a block' do
         callable = ->(result) { result.valid(1) }
 
-        expect { Plumb::Transform[callable] { |r| r.valid(2) } }
+        expect { Plumb::Function[callable] { |r| r.valid(2) } }
           .to raise_error(ArgumentError, /not both/)
-        expect { Plumb::Transform[callable, { String => Integer }] { |r| r.valid(2) } }
+        expect { Plumb::Function[callable, { String => Integer }] { |r| r.valid(2) } }
           .to raise_error(ArgumentError, /not both/)
       end
 
       it 'raises when given arguments it cannot interpret' do
-        expect { Plumb::Transform[42] }.to raise_error(ArgumentError, /expected Plumb/)
-        expect { Plumb::Transform[String] }.to raise_error(ArgumentError, /expected Plumb/)
-        expect { Plumb::Transform[{ String => Integer }, 42] }.to raise_error(ArgumentError, /expected Plumb/)
+        expect { Plumb::Function[42] }.to raise_error(ArgumentError, /expected Plumb/)
+        expect { Plumb::Function[String] }.to raise_error(ArgumentError, /expected Plumb/)
+        expect { Plumb::Function[{ String => Integer }, 42] }.to raise_error(ArgumentError, /expected Plumb/)
       end
     end
   end

--- a/spec/pipeline_spec.rb
+++ b/spec/pipeline_spec.rb
@@ -43,7 +43,7 @@ module Tests
 end
 
 RSpec.describe Plumb::Pipeline do
-  specify '#step(output_type, &block) adds a Transform step' do
+  specify '#step(output_type, &block) adds a Function step' do
     user = Data.define(:name)
     pipeline = Types::Any.pipeline do |pl|
       pl.step Types::Hash[name: Types::String]

--- a/spec/transform_spec.rb
+++ b/spec/transform_spec.rb
@@ -1,0 +1,105 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Plumb::Transform do
+  describe '.[]' do
+    specify 'input => output with a block' do
+      type = Plumb::Transform[String => Integer] { |result| result.valid(result.value.size) }
+
+      expect(type).to be_a(described_class)
+      expect(type.input_type).to eq(Types::String)
+      expect(type.output_type).to eq(Types::Integer)
+      assert_result(type.resolve('abc'), 3, true)
+    end
+
+    specify 'input => output with a callable' do
+      callable = ->(result) { result.valid(result.value.size) }
+      type = Plumb::Transform[callable, String => Integer]
+
+      expect(type).to be_a(described_class)
+      assert_result(type.resolve('abc'), 3, true)
+    end
+
+    it 'validates both ends of the function' do
+      type = Plumb::Transform[String => Integer] { |result| result.valid(result.value.to_s) }
+
+      assert_result(type.resolve(10), 10, false)
+      assert_result(type.resolve('abc'), 'abc', false)
+    end
+
+    it 'wraps Composable types as well as Ruby classes' do
+      type = Plumb::Transform[Types::String => Types::Integer] { |result| result.valid(result.value.size) }
+
+      assert_result(type.resolve('abcd'), 4, true)
+    end
+
+    it 'composes with other steps' do
+      type = Types::String \
+        >> Plumb::Transform[String => Integer] { |r| r.valid(r.value.size) } \
+        >> Plumb::Transform[Integer => String] { |r| r.valid("size: #{r.value}") }
+
+      assert_result(type.resolve('abc'), 'size: 3', true)
+      assert_result(type.resolve(10), 10, false)
+    end
+
+    describe 'identity' do
+      it 'returns the type itself when input and output match and there is nothing to apply' do
+        expect(Plumb::Transform[String => String]).to eq(Types::String)
+      end
+
+      it 'returns Types::Any with no arguments' do
+        expect(Plumb::Transform[]).to eq(Types::Any)
+        expect(Plumb::Transform[{}]).to eq(Types::Any)
+      end
+
+      it 'still builds a Transform when a callable is given' do
+        type = Plumb::Transform[String => String] { |result| result.valid(result.value.upcase) }
+
+        expect(type).to be_a(described_class)
+        assert_result(type.resolve('abc'), 'ABC', true)
+      end
+    end
+
+    specify 'a callable with no types' do
+      type = Plumb::Transform[->(result) { result.valid(result.value * 2) }]
+
+      expect(type.input_type).to eq(Types::Any)
+      expect(type.output_type).to eq(Types::Any)
+      assert_result(type.resolve(2), 4, true)
+    end
+
+    specify 'a block with no types' do
+      type = Plumb::Transform[] { |result| result.valid(result.value * 2) }
+
+      assert_result(type.resolve(2), 4, true)
+      assert_result(type.resolve('ab'), 'abab', true)
+    end
+
+    describe 'argument errors' do
+      it 'raises when types differ but no callable is given' do
+        expect { Plumb::Transform[String => Integer] }.to raise_error(ArgumentError, /no explicit transform/)
+      end
+
+      it 'raises when given more than one input => output pair' do
+        expect { Plumb::Transform[{ String => Integer, Integer => String }] }
+          .to raise_error(ArgumentError, /single key/)
+      end
+
+      it 'raises when given both a callable and a block' do
+        callable = ->(result) { result.valid(1) }
+
+        expect { Plumb::Transform[callable] { |r| r.valid(2) } }
+          .to raise_error(ArgumentError, /not both/)
+        expect { Plumb::Transform[callable, { String => Integer }] { |r| r.valid(2) } }
+          .to raise_error(ArgumentError, /not both/)
+      end
+
+      it 'raises when given arguments it cannot interpret' do
+        expect { Plumb::Transform[42] }.to raise_error(ArgumentError, /expected Plumb/)
+        expect { Plumb::Transform[String] }.to raise_error(ArgumentError, /expected Plumb/)
+        expect { Plumb::Transform[{ String => Integer }, 42] }.to raise_error(ArgumentError, /expected Plumb/)
+      end
+    end
+  end
+end

--- a/spec/type_subtyping_spec.rb
+++ b/spec/type_subtyping_spec.rb
@@ -126,8 +126,8 @@ RSpec.describe 'subtyping: Plumb::Subtyping.subtype? and #<=' do
     end
   end
 
-  describe '#<= over conversions (Transform)' do
-    it 'identifies a Transform by the value it produces (output_type)' do
+  describe '#<= over conversions (Function)' do
+    it 'identifies a Function by the value it produces (output_type)' do
       string_to_int = STypes::String.transform(::Integer, &:to_i)
       expect(string_to_int <= STypes::Integer).to be(true)
       expect(string_to_int <= STypes::String).to be(false)
@@ -490,7 +490,7 @@ RSpec.describe 'subtyping: Plumb::Subtyping.subtype? and #<=' do
   end
 
   describe '#subtype_identity (custom transforming types)' do
-    # A value-converting type built WITHOUT subclassing Transform. It opts into
+    # A value-converting type built WITHOUT subclassing Function. It opts into
     # the "identified by what I produce" rule purely via #subtype_identity.
     class RoundToInt
       include Plumb::Composable
@@ -512,7 +512,7 @@ RSpec.describe 'subtyping: Plumb::Subtyping.subtype? and #<=' do
       expect(to_int <= STypes::Numeric).to be(true)  # produces Integer <= Numeric
       expect(to_int <= STypes::String).to be(false)
       expect(STypes::Integer <= to_int).to be(true)  # Integer <= produced Integer
-      # projects the same way a Transform does
+      # projects the same way a Function does
       expect(to_int <= STypes::Integer.transform(STypes::Numeric) { |r| r }).to be(true)
     end
 

--- a/spec/type_subtyping_spec.rb
+++ b/spec/type_subtyping_spec.rb
@@ -206,6 +206,81 @@ RSpec.describe 'subtyping: Plumb::Subtyping.subtype? and #<=' do
       # a refinement accepts the constraint it passes (its output), not the base
       expect(STypes::Integer[1..10].accepted_type).to eq(STypes::Integer[1..10].output_type)
     end
+
+    it 'a filtered Hash/HashMap accepts any hash-like, not its declared schema' do
+      # #filtered is lenient at runtime — it takes any hash and drops the fields
+      # that don't fit — so as a consumer it must accept more than its
+      # #input_type declares, or `>>` would reject producers it handles fine.
+      filtered = STypes::Hash[name: STypes::String, age: STypes::Integer].filtered
+      expect(filtered.input_type).to eq(STypes::Hash[name: STypes::String, age: STypes::Integer])
+      expect(Plumb::Subtyping.accepted_type(filtered)).to eq(STypes::Interface[:each_pair])
+
+      filtered_map = STypes::Hash[STypes::String, STypes::Integer].filtered
+      expect(Plumb::Subtyping.accepted_type(filtered_map)).to eq(STypes::Interface[:each_pair])
+    end
+  end
+
+  # The engine assumes a node's #input_type / #output_type are themselves
+  # resolved — an And resolves one hop at construction on that basis. Guard it,
+  # and record where it does NOT hold (see the exception below), which is why
+  # Subtyping.resolved_input/resolved_output walk to a fixpoint.
+  describe 'io types are self-resolved' do
+    money = Class.new
+    node_kinds = {
+      'plain type' => STypes::String,
+      'refinement' => STypes::Integer[1..5],
+      'where-clause' => STypes::String.where(size: 1..10),
+      'transform' => STypes::String.transform(::Integer, &:to_i),
+      'chain' => STypes::String.transform(::Integer, &:to_i) >> STypes::Integer.transform(::Integer) { |i| i * 2 },
+      'union' => STypes::String | STypes::Integer,
+      'coercing union' => STypes::String.transform(::Integer, &:to_i) | STypes::Integer,
+      'hash' => STypes::Hash[name: STypes::String],
+      'filtered hash' => STypes::Hash[name: STypes::String].filtered,
+      'hash map' => STypes::Hash[STypes::String, STypes::Integer],
+      'array' => STypes::Array[STypes::String],
+      'tuple' => STypes::Tuple[STypes::String, STypes::Integer],
+      'stream' => STypes::Stream[STypes::String],
+      'static' => STypes::Static['x'],
+      'interface' => STypes::Interface[:to_s],
+      'opaque step' => Plumb::Step.new(->(r) { r }),
+      'function' => Plumb::Function[String => Integer] { |r| r.valid(r.value.size) },
+      'metadata-wrapped' => STypes::String.metadata(foo: 1),
+      'policy-wrapped' => STypes::String.default('x'),
+      'build' => STypes::Integer.build(money) { |_i| money.new },
+      'deferred' => STypes::Any.defer { STypes::String },
+      'pipeline' => STypes::Any.pipeline { |pl| pl.step(STypes::String) }
+    }.freeze
+
+    node_kinds.each do |name, type|
+      specify name do
+        %i[input_type output_type].each do |io|
+          once = type.public_send(io)
+          expect(once.public_send(io)).to eq(once), "#{name}##{io} needs a second hop to resolve"
+        end
+      end
+    end
+
+    it 'does NOT hold for a step whose DECLARED input is itself converting' do
+      # Known exception. Lax::Integer is `Lax::Numeric.transform(::Integer, :to_i)`,
+      # and a Function reports its declared input verbatim — here a coercing union
+      # that resolves further. `Lax::Numeric` is the honest answer to "what do I
+      # declare I consume"; the wider resolved type is "what will I actually
+      # accept". Bridging that gap is exactly what the fixpoint in
+      # Subtyping.resolved_input (and so #accepted_type) is for — do not replace
+      # it with a single hop.
+      declared = STypes::Lax::Integer.input_type
+      expect(declared).to eq(STypes::Lax::Numeric)
+      expect(declared.input_type).not_to eq(declared)
+
+      resolved = Plumb::Subtyping.resolved_input(STypes::Lax::Integer)
+      expect(resolved).to eq(declared.input_type.input_type)
+      expect(resolved).not_to eq(declared)
+
+      # and #accepted_type must report the resolved type, not the declared one:
+      # this is the assertion that fails if the fixpoint is ever swapped for a
+      # single hop.
+      expect(Plumb::Subtyping.accepted_type(STypes::Lax::Integer)).to eq(resolved)
+    end
   end
 
   describe 'composition type-checking (#>>)' do
@@ -265,6 +340,21 @@ RSpec.describe 'subtyping: Plumb::Subtyping.subtype? and #<=' do
       # but a field that consumes an incompatible type still raises
       bad = STypes::Hash[price: STypes::String.build(money)] # its :price consumes a String
       expect { front >> bad }.to raise_error(Plumb::TypeError)
+    end
+
+    it 'lets any hash producer feed a filtered Hash/HashMap (it never rejects)' do
+      schema = STypes::Hash[name: STypes::String, age: STypes::Integer]
+      producer = STypes::Hash[name: STypes::String] # missing :age
+
+      # unfiltered, the missing field is a genuine mismatch
+      expect { producer >> schema }.to raise_error(Plumb::TypeError)
+      # filtered, the consumer drops what doesn't fit rather than rejecting,
+      # so the same chain must build — and pass the fields it can.
+      expect { producer >> schema.filtered }.not_to raise_error
+      expect((producer >> schema.filtered).parse(name: 'x', extra: 1)).to eq(name: 'x')
+
+      filtered_map = STypes::Hash[STypes::String, STypes::Integer].filtered
+      expect { STypes::Hash[STypes::Symbol, STypes::Integer] >> filtered_map }.not_to raise_error
     end
 
     it 'a #check refines its base type, so `check >> typed` composes' do

--- a/spec/types_spec.rb
+++ b/spec/types_spec.rb
@@ -261,7 +261,7 @@ RSpec.describe Plumb::Types do
     end
 
     it 'is shallow for longer chains: input_type is everything but the last step' do
-      # (A >> B >> C) == ((A >> B) >> C). Transform steps keep the And nesting;
+      # (A >> B >> C) == ((A >> B) >> C). Function steps keep the And nesting;
       # each step's output must be a subtype of the next step's input.
       a = Types::Integer[1..5]
       b = Types::Integer.transform(::String, :to_s)

--- a/spec/types_spec.rb
+++ b/spec/types_spec.rb
@@ -250,25 +250,31 @@ RSpec.describe Plumb::Types do
       expect(Types::String.output_type).to eq(Types::String)
     end
 
-    it 'exposes the two sides of a chain (A >> B)' do
+    it 'resolves through a chain (A >> B) to what it consumes and produces' do
       # A value-changing (transform) step keeps the chain as an And. Refinement-
       # only chains collapse via reduction instead (see reduction_spec.rb).
+      # The two sides themselves stay available as #children.
       b = Types::Integer.transform(::String, :to_s)
       chain = Types::Integer >> b
       expect(chain).to be_a(Plumb::And)
       expect(chain.input_type).to eq(Types::Integer)
-      expect(chain.output_type).to eq(b)
+      expect(chain.output_type).to eq(Types::String)
+      expect(chain.children).to eq([Types::Integer, b])
     end
 
-    it 'is shallow for longer chains: input_type is everything but the last step' do
-      # (A >> B >> C) == ((A >> B) >> C). Function steps keep the And nesting;
-      # each step's output must be a subtype of the next step's input.
+    it 'resolves through longer chains, past the intermediate steps' do
+      # (A >> B >> C) == ((A >> B) >> C). Function steps keep the And nesting,
+      # but the chain as a whole only accepts what its first step accepts and
+      # only produces what its last step produces.
       a = Types::Integer[1..5]
       b = Types::Integer.transform(::String, :to_s)
       c = Types::String.transform(::Integer, :to_i)
       chain = a >> b >> c
-      expect(chain.input_type).to eq(a >> b)
-      expect(chain.output_type).to eq(c)
+      expect(chain.input_type).to eq(a)
+      expect(chain.output_type).to eq(Types::Integer)
+      # the nesting is still there — it is just not what the io types report
+      expect(chain.children).to eq([a >> b, c])
+      assert_result(chain.resolve(3), 3, true)
     end
 
     it 'preserves the constrained input type of a transform' do


### PR DESCRIPTION
## What

Rename `Plumb::Transform` to `Plumb::Function`.
`Composable#transform` still creates a `Plumb::Function`, but "Function" is a better generic name (it may or may not transform the value).

### `Plumb::Function[input_type => output_type]`

Also added `Plumb::Function[input_type => output_type]` helper.

```ruby
Coerce = Plumb::Function[String => Integer] do |r|
  r.valid r.value.to_i
end

Double = Plumb::Function[Integer => Integer] do |r|
  r.valid r.value * 2
end

CoerceAndDouble = Coerce >> Double

CoerceAndDouble.parse '20' # => 40
```

Or, with `#call(Result) Result` interface as first argument:

```ruby
Plumb::Function[CustomMultiplier.new(2), Integer => Integer]
```

`Plumb::Function` objects are composable like any other plumb step.

```ruby
Even = Coerce.check(&:even?)
Even.parse '10' # 10
Even.parse '11' # raises Plumb::TypeError
```

## Narrow `And#input_type` and `And#output_type`

Also in this PR: make `Plumb::And` narrow its `#input_type` and `#output_type` to the types actually expected and produced.