### PR TITLE
Fuse Function >> Function compositions into a single Function

### DIFF
--- a/lib/plumb/composable.rb
+++ b/lib/plumb/composable.rb
@@ -327,6 +327,12 @@ module Plumb
     # idempotent).
     def value_preserving? = false
 
+    # Fuse `self >> other` into a single node when the runtime checks at the
+    # boundary between them are provably redundant, or nil when fusion doesn't
+    # apply. A reduction rung in Subtyping.reduce_step, so both `#>>` and `#/`
+    # reach it. See Function#fuse_with, the only implementor.
+    def fuse_with(_other) = nil
+
     # Chain two composable objects together.
     # A.K.A "and" or "sequence"
     # @example

--- a/lib/plumb/function.rb
+++ b/lib/plumb/function.rb
@@ -93,6 +93,38 @@ module Plumb
       result.map(@input_type).map(@fn).map(@output_type)
     end
 
+    # Fuse `self >> other` into a single Function running both fns, dropping
+    # the redundant runtime checks at the boundary: `(A -> B) >> (B -> C)`
+    # becomes `(A -> C)` — the intermediate `B` was proven here, at build time.
+    # Returns nil (no fusion) unless:
+    #   - both #calls are the standard input->fn->output mapping (see #fusible?);
+    #   - what self produces is a DIRECT subtype of what other declares as
+    #     input. check_composable! is looser — it relaxes container fields via
+    #     accepted_type (the `encode >> decode` case), and there other's input
+    #     check does real per-field work and must keep running;
+    #   - the dropped checks are value-preserving: a coercing boundary type
+    #     changes the value, so it must keep running. self's output check needs
+    #     this only when it exists at all (a GuaranteedFunction carries none).
+    def fuse_with(other)
+      return nil unless fusible?(self) && fusible?(other)
+      return nil unless Plumb::Subtyping.subtype?(@output_type, other.input_type)
+      return nil unless Plumb::Subtyping.value_preserving?(other.input_type)
+      return nil unless is_a?(GuaranteedFunction) || Plumb::Subtyping.value_preserving?(@output_type)
+
+      fn1 = @fn
+      fn2 = other.fn
+      # other.class keeps Guaranteed-ness: the final output check survives iff
+      # `other` carried one.
+      other.class.new(@input_type, other.output_type, ->(result) { result.map(fn1).map(fn2) })
+    end
+
+    # #call must be exactly the standard input->fn->output mapping for its
+    # checks to be droppable — an exact-class whitelist (instance_of?), not
+    # is_a?: FilteredHash is a Function subclass whose custom #call skips the
+    # input check, so it must not fuse. GuaranteedFunction is listed separately
+    # because instance_of? never matches through inheritance.
+    private def fusible?(node) = node.instance_of?(Function) || node.instance_of?(GuaranteedFunction)
+
     # A Function's subtyping identity is what it produces — its declared,
     # distinct output_type. See Plumb::Subtyping.subtype? and Composable#subtype_identity.
     def subtype_identity = @output_type

--- a/lib/plumb/subtyping.rb
+++ b/lib/plumb/subtyping.rb
@@ -241,6 +241,14 @@ module Plumb
       # `.where(size: 10..40)`, one `String` check.
       return narrow_attribute(left, right) if right.is_a?(AttributeValueMatch)
 
+      # Two adjacent converting steps whose boundary is provable at build time
+      # fuse into one node: `(A -> B) >> (B -> C)` becomes `(A -> C)` running
+      # both fns, dropping the redundant out/in checks between them. fuse_with
+      # carries its own subtype proof, so it is sound from #>> and #/ alike.
+      if (fused = left.fuse_with(right))
+        return fused
+      end
+
       return nil unless right.is_a?(Constraint)
 
       matchers = [] # innermost-first, excludes the root gate

--- a/spec/function_fusion_spec.rb
+++ b/spec/function_fusion_spec.rb
@@ -1,0 +1,130 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe 'Function fusion' do
+  subject(:fused) { append >> prepend }
+
+  let(:append) { Plumb::Function[String => String] { |r| r.valid(r.value + 'aa') } }
+  let(:prepend) { Plumb::Function[String => String] { |r| r.valid('bbbb' + r.value) } }
+  let(:int_from_string) { Types::String.transform(::Integer, :to_i) }
+
+  it 'fuses two Functions with a provable boundary into a single Function' do
+    expect(fused).to be_instance_of(Plumb::Function)
+    expect(fused.input_type).to eq(Types::String)
+    expect(fused.output_type).to eq(Types::String)
+    assert_result(fused.resolve('x'), 'bbbbxaa', true)
+  end
+
+  it 'still validates the fused ends' do
+    assert_result(fused.resolve(10), 10, false)
+
+    lying = Plumb::Function[String => String] { |r| r.valid(r.value) } \
+      >> Plumb::Function[String => Integer] { |r| r.valid(r.value) }
+
+    expect(lying).to be_instance_of(Plumb::Function)
+    assert_result(lying.resolve('x'), 'x', false)
+  end
+
+  it 'fuses left-to-right across longer chains' do
+    third = Plumb::Function[String => String] { |r| r.valid(r.value + 'cc') }
+    chain = append >> prepend >> third
+
+    expect(chain).to be_instance_of(Plumb::Function)
+    assert_result(chain.resolve('x'), 'bbbbxaacc', true)
+  end
+
+  it 'fuses untyped functions' do
+    f1 = Plumb::Function[->(r) { r.valid(r.value * 2) }]
+    f2 = Plumb::Function[->(r) { r.valid(r.value + 1) }]
+    chain = f1 >> f2
+
+    expect(chain).to be_instance_of(Plumb::Function)
+    assert_result(chain.resolve(3), 7, true)
+  end
+
+  it 'short-circuits the fn chain when an fn invalidates' do
+    seen = []
+    failing = Plumb::Function[String => String] { |r| r.invalid(errors: 'nope') }
+    tracking = Plumb::Function[String => String] do |r|
+      seen << r.value
+      r.valid(r.value)
+    end
+    chain = failing >> tracking
+
+    expect(chain).to be_instance_of(Plumb::Function)
+    expect(chain.resolve('x').valid?).to be(false)
+    expect(seen).to be_empty
+  end
+
+  it 'fuses through the #/ escape hatch too' do
+    chain = append / prepend
+
+    expect(chain).to be_instance_of(Plumb::Function)
+    assert_result(chain.resolve('x'), 'bbbbxaa', true)
+  end
+
+  it 'keeps Guaranteed-ness from the right side' do
+    expect(int_from_string).to be_instance_of(Plumb::GuaranteedFunction)
+
+    chain = append >> int_from_string
+    expect(chain).to be_instance_of(Plumb::GuaranteedFunction)
+    assert_result(chain.resolve('1'), 1, true)
+
+    back_to_plain = int_from_string >> Plumb::Function[Integer => String] { |r| r.valid(r.value.to_s) }
+    expect(back_to_plain).to be_instance_of(Plumb::Function)
+    assert_result(back_to_plain.resolve('5'), '5', true)
+  end
+
+  it 'survives decoration' do
+    decorated = Plumb::Decorator.(fused) { |type| type }
+
+    expect(decorated).to be_instance_of(Plumb::Function)
+    assert_result(decorated.resolve('x'), 'bbbbxaa', true)
+  end
+
+  describe 'compositions that must NOT fuse' do
+    it 'keeps an And when the right input type converts the value' do
+      right = Plumb::Function[int_from_string => Integer] { |r| r.valid(r.value + 1) }
+      composed = append >> right
+
+      expect(composed).to be_a(Plumb::And)
+      # 'x' -> 'xaa' -> coerced by the right's input ('xaa'.to_i => 0) -> 1.
+      # A fused chain would have fed the String straight to the fn and raised.
+      assert_result(composed.resolve('x'), 1, true)
+    end
+
+    it 'keeps an And when the left output type converts the value' do
+      left = Plumb::Function[Types::String => int_from_string] { |r| r.valid(r.value) }
+      right = Plumb::Function[Integer => Integer] { |r| r.valid(r.value + 1) }
+      composed = left >> right
+
+      expect(composed).to be_a(Plumb::And)
+      assert_result(composed.resolve('5'), 6, true)
+    end
+
+    it 'keeps an And when composition is only valid via accepted-type relaxation' do
+      left = Plumb::Function[Types::Any => Types::Hash[flags: Types::String]] do |r|
+        r.valid(flags: r.value.to_s)
+      end
+      right = Plumb::Function[Types::Hash[flags: int_from_string] => Types::Hash[flags: Types::Integer]] do |r|
+        r.valid(r.value)
+      end
+      composed = left >> right
+
+      expect(composed).to be_a(Plumb::And)
+      # The right's input check does real per-field work: {flags: '5'} -> {flags: 5}.
+      assert_result(composed.resolve(5), { flags: 5 }, true)
+    end
+
+    it 'keeps an And around subclasses with custom #call semantics' do
+      custom_call = Class.new(Plumb::Function) do
+        def call(result) = fn.call(result)
+      end.new(Types::String, Types::String, ->(r) { r.valid(r.value.upcase) })
+
+      expect(append >> custom_call).to be_a(Plumb::And)
+      expect(custom_call >> prepend).to be_a(Plumb::And)
+      assert_result((append >> custom_call).resolve('x'), 'XAA', true)
+    end
+  end
+end

--- a/spec/type_subtyping_spec.rb
+++ b/spec/type_subtyping_spec.rb
@@ -377,8 +377,9 @@ RSpec.describe 'subtyping: Plumb::Subtyping.subtype? and #<=' do
       # equal matcher built separately still collapses
       expect(STypes::String >> STypes::Any[::String]).to eq(STypes::String)
       # but a transform is NOT idempotent — `X >> X` must apply it twice
+      # (it fuses into a single Function running both fns; see Function#fuse_with)
       plus5 = STypes::Any.transform(::Integer) { |v| v + 5 }
-      expect(plus5 >> plus5).to be_a(Plumb::And)
+      expect(plus5 >> plus5).to be_a(Plumb::Function)
       expect((plus5 >> plus5).resolve(10).value).to eq(20)
     end
 


### PR DESCRIPTION
## What

When two `Plumb::Function`s compose with `>>` and the boundary between them is provable at build time, they now fuse into a single `Function` running both fns, instead of an `And` node re-checking the boundary at runtime:

```ruby
a = Plumb::Function[String => String] { |r| r.valid(r.value + 'aa') }
b = Plumb::Function[String => String] { |r| r.valid('bbbb' + r.value) }
c = a >> b

c.class            # Plumb::Function (was Plumb::And)
c.inspect          # (String -> String)
c.resolve('x')     # valid: "bbbbxaa"
c.resolve(1)       # invalid — the fused ends are still checked
```

Before, `c#call` ran six steps: `in₁ → fn1 → out₁ → in₂ → fn2 → out₂`. Fused it runs four: `in₁ → fn1 → fn2 → out₂` — the intermediate `out₁`/`in₂` checks were proven redundant when the composition was built, so they're simply absent, in the same spirit as `GuaranteedFunction` and the existing `>>` reductions (idempotent collapse, `reduce_step`, `redundant_refinement?`).

Chains fuse left-to-right into one node:

```ruby
size    = Plumb::Function[String => Integer] { |r| r.valid(r.value.size) }
double  = Plumb::Function[Integer => Integer] { |r| r.valid(r.value * 2) }
label   = Plumb::Function[Integer => String]  { |r| r.valid("n: #{r.value}") }

(size >> double >> label).class    # Plumb::Function — one node, three fns
```

## How

A single new extension point, `Composable#fuse_with(other)` (default `nil`), invoked as a rung in `Subtyping.reduce_step` — so both `#>>` and `#/` (via `constrain`) reach it with no changes to either operator. `Function#fuse_with` is the only implementor. It's sound on the `#/` path (which skips `check_composable!`) because the rung carries its own subtype proof.

Fusion bails to the usual `And` unless all of:

- **Both `#call`s are the standard `input → fn → output` mapping** — an exact-class whitelist (`instance_of?(Function) || instance_of?(GuaranteedFunction)`), so subclasses with custom call semantics (`FilteredHash`) never fuse, on either side.
- **The boundary is a *direct* subtype** — `subtype?(a.output_type, b.input_type)`. `check_composable!` is looser (it relaxes container fields via `accepted_type`, the `encode >> decode` case); there the right's input check does real per-field work and keeps running:

  ```ruby
  int_from_string = Types::String.transform(::Integer, :to_i)
  right = Plumb::Function[Types::Hash[flags: int_from_string] => Types::Hash[flags: Integer]] { |r| r.valid(r.value) }
  # left producing {flags: '5'} composes, but stays an And —
  # the right's input check still coerces flags to 5.
  ```

- **The dropped boundary types are value-preserving** — a coercing boundary (e.g. `int_from_string` as an input or output type) changes the value, so it keeps running and the pair stays an `And`.

Guaranteed-ness carries through via `other.class.new(...)`: the fused node keeps the final output check iff the right side had one:

```ruby
to_int = Types::String.transform(::Integer, :to_i)   # GuaranteedFunction
(a >> to_int).class                                  # Plumb::GuaranteedFunction — no output re-check
```

## Notes

- The fused fn is a plain lambda chaining `Result#map` — identical short-circuit-on-invalid semantics to `Function#call` / `And#call`.
- Fused nodes are ordinary `:function` nodes for equality, subtyping, visitors, and the Decorator.
- One existing spec updated: the `plus5 >> plus5` counter-case asserted the `And` shape; its invariant (a transform applies twice, `10 -> 20`) still holds — it's now a fused `Function`.

## Testing

- New `spec/function_fusion_spec.rb`: 12 examples — fused happy path, end validation, chains, untyped fns, short-circuiting, `#/`, Guaranteed class selection, decoration round-trip, and four must-not-fuse cases asserting behavior (not just node class).
- Full suite: 665 examples, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)