### PR TITLE
Fix benches and examples broken on main

### DIFF
--- a/bench/json_schema_profile.rb
+++ b/bench/json_schema_profile.rb
@@ -3,27 +3,20 @@
 # Profiles JSON Schema GENERATION (the JSONSchemaVisitor traversal) for a
 # realistic, deeply nested REST API payload — an e-commerce "Order" resource
 # with a customer, addresses, line items, enums, coercing composite types
-# (Forms::Date, Lax::Integer/Decimal/String, Forms::Boolean) and unions.
+# (a Forms-coerced date and boolean, Lax::Integer/Decimal/String) and unions.
 #
-# The branch reduces compositions at build time (union absorption/factoring,
+# Compositions are reduced at build time (union absorption/factoring,
 # refinement/where collapse), so the type GRAPH the visitor walks is smaller and
-# the emitted schema is flatter (folded anyOf, factored enums). This measures
-# whether that shows up in generation cost.
+# the emitted schema is flatter (folded anyOf, factored enums). This measures the
+# resulting generation cost — run it before and after a change to compare.
 #
-# Run on both and compare:
-#   git stash && git checkout main
-#   bundle exec ruby bench/json_schema_profile.rb | tee /tmp/js_main.txt
-#   git checkout - && git stash pop
-#   bundle exec ruby bench/json_schema_profile.rb | tee /tmp/js_branch.txt
-#
-# Public API only (loads on main, which has no Plumb::Subtyping).
-# NB: there is no Types::Lax::Date; the coercing date is Types::Forms::Date.
+# Public API only. NB: there is no Types::Lax::Date; a coercing date/boolean is
+# `real type | the matching Codec::Forms encoder` (see FormsDate / FormsBoolean).
 
 require 'plumb'
 require 'json'
 require 'date'
 
-VERSION_LABEL = defined?(Plumb::Subtyping) ? 'branch (reduced)' : 'main (naive)'
 ITERS = 20_000
 
 module T
@@ -34,8 +27,16 @@ EMAIL = /\A[^@\s]+@[^@\s]+\.[^@\s]+\z/
 SKU   = /\A[A-Z0-9\-]+\z/
 REF   = /\A[A-Z0-9]{8,}\z/
 
-# Enums built as unions of literal String constraints — the branch factors the
-# shared `String` gate into one `anyOf`; main leaves a nested Or.
+# Coercing scalars: "accept the parsed Ruby value, or decode the stringly form" —
+# the same shape as `Types::Lax::*`, built from the Forms codec's encoders. Both
+# branches matter here: a coercing field is exactly what makes the visitor fold a
+# union into one field spec.
+FORMS = Plumb::Codec::Forms
+FormsDate = T::Date | FORMS::DateEncoder
+FormsBoolean = T::Boolean | FORMS::TrueEncoder | FORMS::FalseEncoder
+
+# Enums built as unions of literal String constraints — factoring pulls the shared
+# `String` gate out into one `anyOf`.
 Currency = T::String['USD'] | T::String['EUR'] | T::String['GBP']
 Status   = T::String['pending'] | T::String['paid'] | T::String['shipped'] | T::String['cancelled']
 
@@ -60,8 +61,8 @@ Customer = T::Hash[
   name: T::String.where(size: 1..100),
   email: T::String[EMAIL],
   phone: (T::String | T::Nil),
-  verified: T::Forms::Boolean,
-  loyalty_points: (T::Integer | T::Numeric), # value-preserving union -> Numeric on branch
+  verified: FormsBoolean,
+  loyalty_points: (T::Integer | T::Numeric), # value-preserving union -> absorbs to Numeric
   address: Address,
   billing_address: Address
 ]
@@ -71,9 +72,9 @@ ORDER = T::Hash[
   reference: T::String[REF],
   status: Status,
   currency: Currency,
-  created_at: T::Forms::Date,
-  updated_at: T::Forms::Date,
-  shipped_at: (T::Forms::Date | T::Nil),
+  created_at: FormsDate,
+  updated_at: FormsDate,
+  shipped_at: (FormsDate | T::Nil),
   subtotal: T::Lax::Decimal,
   tax: T::Lax::Decimal,
   total: T::Lax::Decimal,
@@ -98,7 +99,7 @@ schema = ORDER.to_json_schema(root: true)
 json_bytes = JSON.generate(schema).bytesize
 us_per, allocs_per = measure_generation(ORDER)
 
-puts "== plumb JSON Schema generation — #{VERSION_LABEL} — Ruby #{RUBY_VERSION} =="
+puts "== plumb JSON Schema generation — Ruby #{RUBY_VERSION} =="
 puts format('%-26s %s', 'payload', 'REST "Order" (nested: customer, 2 addresses, line items, enums, coercers)')
 puts format('%-26s %.1f', 'us / generation', us_per / 1000.0)
 puts format('%-26s %.0f', 'allocs / generation', allocs_per)

--- a/bench/plumb_hash.rb
+++ b/bench/plumb_hash.rb
@@ -12,7 +12,11 @@ module PlumbHash
   BLANK_STRING = ''
   MONEY_EXP = /(\W{1}|\w{3})?[\d+,.]/
 
-  BlankStringOrDate = Forms::Nil | Forms::Date
+  # Blank string (or a valueless param) -> nil, otherwise an ISO date string -> Date.
+  # Mirrors DryTypesHash's `T::Params::Date.optional`, which is what this file is
+  # benchmarked against.
+  FormEncoders = Plumb::Codec::Forms
+  BlankStringOrDate = FormEncoders::NilEncoder | FormEncoders::DateEncoder
 
   # STUB_MONEY swaps the Monetize-parsing constructor for an identity
   # passthrough, so the benchmark can measure the schema WITHOUT the (shared)

--- a/bench/results_allocations.rb
+++ b/bench/results_allocations.rb
@@ -1,11 +1,24 @@
 # frozen_string_literal: true
 
-# Surfaces where Plumb allocates Result objects (and error strings/containers)
-# while parsing. The headline metric is throwaway `Result::Invalid` objects:
-# these are allocated even on SUCCESSFUL parses whenever a value matches a
-# non-first branch of a union (`A | B`, `Lax::*`, `nullable`, defaults, enums),
-# because `Or#call` tries each branch in turn and each miss materialises an
-# Invalid that is then discarded.
+# Surfaces the throwaway work Plumb does while parsing — Result objects, error
+# strings and containers that are built and then discarded.
+#
+# The headline metric is INVALID TRANSITIONS: how many times a Result is flipped to
+# invalid during a parse, including SUCCESSFUL ones. A value matching a non-first
+# branch of a union (`A | B`, `Lax::*`, `nullable`, defaults, enums) pays for every
+# branch it fell through, because `Or#call` tries each in turn and each miss runs,
+# builds an error payload, and flips the cursor.
+#
+# This counts flips rather than `Result::Invalid` objects because there is no such
+# class: Valid and Invalid were collapsed into one Result carrying a boolean, which
+# is what lets the built-ins reuse the cursor in place (`#invalid!`) instead of
+# allocating one per miss. That collapse removed the ALLOCATION but not the WORK,
+# and the work is what this bench is about — so the flip is the honest successor to
+# the old object count.
+#
+# The `Result` row is the other half of the picture, and shows the collapse paying
+# off: it stays FLAT across all three regimes (4 per record) while the flips go
+# 0 -> 5 -> 14. Misses cost work, but no longer cost an allocation.
 #
 # Three payload regimes are run over the SAME schema so the difference is purely
 # the data, not the types:
@@ -21,16 +34,22 @@ Bundler.setup(:benchmark)
 require 'plumb'
 require 'memory_profiler'
 
-# Count every Result::Invalid ever constructed, so we can report the exact
-# per-record figure independently of the sampling profiler.
-$invalid_allocs = 0
-module CountInvalidAllocs
-  def initialize(*args, **kwargs)
-    $invalid_allocs += 1
+# Count every flip to invalid, so the per-record figure is exact rather than
+# sampled. Both forms are counted: #invalid allocates a fresh Result (the safe form
+# user code uses), #invalid! flips the receiver (the built-ins' hot path).
+$invalid_transitions = 0
+module CountInvalidTransitions
+  def invalid(*args, **kwargs)
+    $invalid_transitions += 1
+    super
+  end
+
+  def invalid!(*args, **kwargs)
+    $invalid_transitions += 1
     super
   end
 end
-Plumb::Result::Invalid.prepend(CountInvalidAllocs)
+Plumb::Result.prepend(CountInvalidTransitions)
 
 module Bench
   include Plumb::Types
@@ -57,21 +76,20 @@ REGIMES = {
   'fully invalid'      => { name: '',    age: 'xx', role: 'nope',   contact: 123 }
 }.freeze
 
-REPORTED_CLASSES = [
-  'Plumb::Result::Valid',
-  'Plumb::Result::Invalid',
-  'String',
-  'Array',
-  'Hash'
+REPORTED_CLASSES = %w[
+  Plumb::Result
+  String
+  Array
+  Hash
 ].freeze
 
 def run_regime(row)
   # warm (fill caches, JIT) and confirm validity classification
   valid = Bench::Record.resolve(row).valid?
 
-  $invalid_allocs = 0
+  $invalid_transitions = 0
   report = MemoryProfiler.report { N.times { Bench::Record.resolve(row) } }
-  invalid = $invalid_allocs
+  invalid = $invalid_transitions
 
   by_class = report.allocated_objects_by_class.each_with_object(Hash.new(0)) do |h, acc|
     acc[h[:data]] = h[:count]
@@ -97,13 +115,11 @@ puts header
 puts 'valid output?'.ljust(LABEL_W) + results.values.map { |r| cell.call(r[:valid]) }.join
 rule(header.size)
 
-# Headline: throwaway Invalid objects (exact count via the constructor counter).
-puts 'Result::Invalid'.ljust(LABEL_W) + results.values.map { |r| count.call(r[:invalid]) }.join
+# Headline: flips to invalid (exact count, not sampled).
+puts 'invalid flips'.ljust(LABEL_W) + results.values.map { |r| count.call(r[:invalid]) }.join
 
-# Other tracked classes, from the sampling profiler.
+# Allocations, from the sampling profiler.
 REPORTED_CLASSES.each do |klass|
-  next if klass == 'Plumb::Result::Invalid' # already shown (exact count)
-
   puts klass.sub('Plumb::', '').ljust(LABEL_W) +
        results.values.map { |r| count.call(r[:by_class][klass]) }.join
 end
@@ -114,8 +130,8 @@ puts 'TOTAL objects'.ljust(LABEL_W) + results.values.map { |r| count.call(r[:tot
 # Order sensitivity: the SAME union, matching the first vs the last branch.
 puts "\nOrder sensitivity — (Value[a] | Value[b] | Value[c]).resolve(x), #{N}x each:"
 [%w[admin first], %w[viewer last]].each do |value, position|
-  $invalid_allocs = 0
+  $invalid_transitions = 0
   N.times { Bench::Role.resolve(value) }
-  puts format('  match %-5s branch (%-6s): %d Invalid allocs (%.2f/record)',
-              position, value, $invalid_allocs, $invalid_allocs.to_f / N)
+  puts format('  match %-5s branch (%-6s): %d invalid flips (%.2f/record)',
+              position, value, $invalid_transitions, $invalid_transitions.to_f / N)
 end

--- a/examples/concurrent_downloads.rb
+++ b/examples/concurrent_downloads.rb
@@ -55,7 +55,9 @@ module Types
       image = result.value
       path = path_for(image.url)
       File.open(path, 'wb') { |f| f.write(image.io.read) }
-      result.valid image.where(url: path, io: File.new(path))
+      # `#with` — the copy-with-changes method on a Ruby ::Data. (Not Plumb's
+      # `#where`, which builds a refined TYPE; `image` here is a Data instance.)
+      result.valid image.with(url: path, io: File.new(path))
     end
 
     def path_for(url)
@@ -79,7 +81,11 @@ cache = Types::Cache.new('./examples/data/downloads')
 # 1). Take a valid URL string.
 # 2). Attempt reading the file from the cache. Return that if it exists.
 # 3). Otherwise, download the file from the internet and write it to the cache.
-IdempotentDownload = Types::Forms::URI::HTTP >> (cache.read | (Types::Download >> cache.write))
+# The leading step turns a URL string into a URI::HTTP (HTTPS included — it is a
+# subclass). The encoder composes here in its decode direction
+# (String -> URI::HTTP), picked automatically from what the rest of the pipeline
+# consumes.
+IdempotentDownload = Plumb::Codec::Forms::HTTPURIEncoder >> (cache.read | (Types::Download >> cache.write))
 
 # An array of downloadable images,
 # marked as concurrent so that all IO operations are run in threads.

--- a/examples/event_registry.rb
+++ b/examples/event_registry.rb
@@ -14,6 +14,11 @@ module Types
   # Turn an ISO8601 string into a Time object
   ISOTime = String.build(::Time, :parse).policy(:rescue, ArgumentError)
 
+  # An already-parsed Time, or an ISO8601 string coerced into one. Use
+  # `Plumb::Codec::Forms::TimeEncoder` instead if you also want to encode back to
+  # a string; ISOTime above covers the one direction this example needs.
+  Timestamp = Time | ISOTime
+
   # A UUID string, or generate a new one
   AutoUUID = UUID::V4.default { SecureRandom.uuid }
 end
@@ -57,7 +62,7 @@ class Event < Types::Data
   attribute :id, Types::AutoUUID
   attribute :stream_id, Types::String.present
   attribute :type, Types::String
-  attribute(:created_at, Types::Forms::Time.default { ::Time.now })
+  attribute(:created_at, Types::Timestamp.default { ::Time.now })
   attribute? :causation_id, Types::UUID::V4
   attribute? :correlation_id, Types::UUID::V4
   attribute :payload, Types::Static[nil]


### PR DESCRIPTION
Five files under `bench/` and `examples/` do not run on `main`. They reference constants that were removed by earlier merges, so they die on load — nothing to do with any in-flight work.

These were fixed in passing on the `refactor-type-computation-split` branch (#43); this extracts them so they land independently of that refactor.

## What was broken

| file | referenced | which is |
|---|---|---|
| `bench/plumb_hash.rb` | `Forms::Nil`, `Forms::Date` | gone with `Types::Forms` |
| `bench/json_schema_profile.rb` | `Types::Forms::{Date,Boolean}` | gone with `Types::Forms` |
| `examples/event_registry.rb` | `Types::Forms::Time` | gone with `Types::Forms` |
| `examples/concurrent_downloads.rb` | `Types::Forms::URI::HTTP` | gone with `Types::Forms` |
| `bench/results_allocations.rb` | `Plumb::Result::Invalid` | collapsed into `Result` |

## What the fixes do

Each is rebuilt on the API that replaced the removed one — `Plumb::Codec::Forms` for the coercing scalars, and a flip counter for the Result work:

```ruby
Forms::Nil | Forms::Date   ->  Codec::Forms::NilEncoder | Codec::Forms::DateEncoder
Types::Forms::Boolean      ->  Boolean | TrueEncoder | FalseEncoder
Types::Forms::URI::HTTP    ->  Codec::Forms::HTTPURIEncoder
Types::Forms::Time         ->  Time | ISOTime            # the example's own parser
```

`results_allocations.rb` counted throwaway `Result::Invalid` allocations. Since `Valid` and `Invalid` were collapsed into one `Result` carrying a boolean, it now counts **flips to invalid** (`#invalid` and `#invalid!`). That is the honest successor: the collapse removed the allocation but not the work, and the work is what the bench is about. The output shows the collapse paying off — flips go `0 -> 5 -> 14` per record across the three regimes while `Result` allocations stay flat at 4.

## Two unrelated fixes in the same files

- `examples/concurrent_downloads.rb` called `::Data#where`, which does not exist. It meant `#with`, the copy-with-changes method — Plumb's `#where` builds a refined *type*, which is not what a `Data` instance wants.
- `bench/json_schema_profile.rb` carried a `VERSION_LABEL` keyed off `defined?(Plumb::Subtyping)` plus `git checkout` instructions, to compare two branches. `Subtyping` is on main now, so the label always reads the same; both dropped.

## Verification

**14 of the 17** files under `bench/` and `examples/` run clean. `bundle exec rspec` is unchanged at **687 examples, 0 failures** — there are no `lib/` or `spec/` changes here.

The other three:

- `bench/plumb_hash.rb` and `bench/dry_types_hash.rb` raise `Money::Currency::NoCurrency` — the `money` gem has no default currency configured in this environment. Pre-existing and unrelated; they fail identically on `main`, and `plumb_hash.rb` now gets well past the `Forms` fix before hitting it.
- `examples/concurrent_downloads.rb` **was not executed** — it downloads images over the network. Its two fixes were verified indirectly instead: `Plumb::Codec::Forms::HTTPURIEncoder` resolves on `main`, and `::Data#with` behaves as the replacement for the non-existent `#where`. Worth a manual run before merging if you want it covered.

For `results_allocations.rb` I re-ran the figures its header comment cites, since they had been measured on another branch. On `main` they come out exactly as documented — flips `0 -> 5 -> 14` per record across the three regimes, `Result` allocations flat at 4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
