### PR TITLE
Make the subtype relation agree with runtime behaviour

### DIFF
--- a/lib/plumb.rb
+++ b/lib/plumb.rb
@@ -64,6 +64,18 @@ module Plumb
   #
   # This is a temporary helper to preserve type-specific policy resolution
   # (see Composable#policy) until proper subtyping checks are implemented.
+  # The base class to report for a matcher that compares VALUES — a literal, a
+  # Range endpoint, a Static's value.
+  #
+  # Numerics compare equal across their classes (`5 == 5.0`) and Ranges of them
+  # match across classes too (`(1..10) === 2.5`), so a numeric value describes
+  # Numeric rather than only its own class. Reporting Integer would let
+  # Subtyping.disjoint_atomic? call `Types::Any[5]` and Types::Float disjoint and
+  # sink their intersection to Never, though `5.0` satisfies both.
+  def self.value_base_class(value)
+    value.is_a?(::Numeric) ? ::Numeric : value.class
+  end
+
   def self.resolve_base_types(node)
     return [node] if node.is_a?(::Class)
     return [] unless node.respond_to?(:node_name)
@@ -104,16 +116,31 @@ module Plumb
       matcher = node.children.first
       case matcher
       when ::Class then [matcher]
-      when ::Regexp then [::String]
-      when ::Range then [(matcher.begin || matcher.end).class]
-      else [matcher.class]
+      # `Regexp#===` coerces, so a pattern matches Symbols as well as Strings
+      # (`/x/ === :xyz` is true). Reporting only String would let callers treat a
+      # pattern as String-only — eg. an Interface check that a Symbol fails.
+      when ::Regexp then [::String, ::Symbol]
+      when ::Range then [value_base_class(matcher.begin || matcher.end)]
+      else [value_base_class(matcher)]
       end
     when :array, :tuple then [::Array]
     when :hash, :hash_map, :tagged_hash, :filtered_hash, :filtered_hash_map then [::Hash]
     when :stream then [::Enumerator]
+    when :range then [::Range]
+    when :not
+      # A negation describes the COMPLEMENT of what it wraps — every value except
+      # those. That is not expressible as a list of base classes (and the wrapped
+      # type's own classes are precisely the ones excluded), so report "unknown"
+      # and let callers stay conservative.
+      []
+    when :value
+      # A literal matched by `==`. Same rule as :static — the value describes its
+      # own class, widened for numerics.
+      value = node.children.first
+      value.equal?(Undefined) ? [] : [value_base_class(value)]
     when :static
       value = node.children.first
-      [value.is_a?(::Class) ? value : value.class]
+      [value.is_a?(::Class) ? value : value_base_class(value)]
     else
       node.respond_to?(:children) ? node.children.flat_map { |child| resolve_base_types(child) } : []
     end

--- a/lib/plumb.rb
+++ b/lib/plumb.rb
@@ -64,14 +64,12 @@ module Plumb
   #
   # This is a temporary helper to preserve type-specific policy resolution
   # (see Composable#policy) until proper subtyping checks are implemented.
-  # The base class to report for a matcher that compares VALUES — a literal, a
-  # Range endpoint, a Static's value.
-  #
-  # Numerics compare equal across their classes (`5 == 5.0`) and Ranges of them
-  # match across classes too (`(1..10) === 2.5`), so a numeric value describes
-  # Numeric rather than only its own class. Reporting Integer would let
-  # Subtyping.disjoint_atomic? call `Types::Any[5]` and Types::Float disjoint and
-  # sink their intersection to Never, though `5.0` satisfies both.
+  # Returns the value's matching domain, widened to Numeric because numeric
+  # equality crosses concrete classes (`5 == 5.0`).
+  # Keeping a concrete numeric class would falsely make compatible literal and
+  # numeric types appear disjoint and reduce their intersection to Never.
+  # @param value [Object]
+  # @return [Class]
   def self.value_base_class(value)
     value.is_a?(::Numeric) ? ::Numeric : value.class
   end
@@ -116,9 +114,7 @@ module Plumb
       matcher = node.children.first
       case matcher
       when ::Class then [matcher]
-      # `Regexp#===` coerces, so a pattern matches Symbols as well as Strings
-      # (`/x/ === :xyz` is true). Reporting only String would let callers treat a
-      # pattern as String-only — eg. an Interface check that a Symbol fails.
+      # Regexp#=== coerces both Strings and Symbols.
       when ::Regexp then [::String, ::Symbol]
       when ::Range then [value_base_class(matcher.begin || matcher.end)]
       else [value_base_class(matcher)]
@@ -128,14 +124,10 @@ module Plumb
     when :stream then [::Enumerator]
     when :range then [::Range]
     when :not
-      # A negation describes the COMPLEMENT of what it wraps — every value except
-      # those. That is not expressible as a list of base classes (and the wrapped
-      # type's own classes are precisely the ones excluded), so report "unknown"
-      # and let callers stay conservative.
+      # A complement has no finite base-class representation.
       []
     when :value
-      # A literal matched by `==`. Same rule as :static — the value describes its
-      # own class, widened for numerics.
+      # Literals match by ==, including across numeric classes.
       value = node.children.first
       value.equal?(Undefined) ? [] : [value_base_class(value)]
     when :static

--- a/lib/plumb.rb
+++ b/lib/plumb.rb
@@ -70,9 +70,7 @@ module Plumb
   # numeric types appear disjoint and reduce their intersection to Never.
   # @param value [Object]
   # @return [Class]
-  def self.value_base_class(value)
-    value.is_a?(::Numeric) ? ::Numeric : value.class
-  end
+  def self.value_base_class(value) = SemanticMatcher.value_domain(value)
 
   def self.resolve_base_types(node)
     return [node] if node.is_a?(::Class)
@@ -111,14 +109,7 @@ module Plumb
       # `Integer[1..10]` => [Integer], `User.check {}` => the User's base types).
       return resolve_base_types(node.base) if node.base
 
-      matcher = node.children.first
-      case matcher
-      when ::Class then [matcher]
-      # Regexp#=== coerces both Strings and Symbols.
-      when ::Regexp then [::String, ::Symbol]
-      when ::Range then [value_base_class(matcher.begin || matcher.end)]
-      else [value_base_class(matcher)]
-      end
+      SemanticMatcher.matcher_domain(node.children.first)
     when :array, :tuple then [::Array]
     when :hash, :hash_map, :tagged_hash, :filtered_hash, :filtered_hash_map then [::Hash]
     when :stream then [::Enumerator]
@@ -141,6 +132,8 @@ end
 
 require 'plumb/result'
 require 'plumb/type_registry'
+require 'plumb/relation'
+require 'plumb/semantic_matcher'
 require 'plumb/composable'
 require 'plumb/typed_step'
 require 'plumb/node_mapper'

--- a/lib/plumb/attribute_value_match.rb
+++ b/lib/plumb/attribute_value_match.rb
@@ -56,6 +56,12 @@ module Plumb
     end
 
     def call(result)
+      # A value that has no such attribute fails the constraint — it cannot "have
+      # attribute X" — rather than raising NoMethodError. #input_type is Any (this
+      # narrows by value and opts out of #>> checks), so nothing upstream
+      # guarantees the attribute exists: `Types::Any.where(upcase: 'X')` is handed
+      # whatever the caller passes.
+      return result.invalid!(errors: @error) unless result.value.respond_to?(attr_name)
       return result if value === result.value.public_send(attr_name)
 
       result.invalid!(errors: @error)

--- a/lib/plumb/attribute_value_match.rb
+++ b/lib/plumb/attribute_value_match.rb
@@ -56,11 +56,7 @@ module Plumb
     end
 
     def call(result)
-      # A value that has no such attribute fails the constraint — it cannot "have
-      # attribute X" — rather than raising NoMethodError. #input_type is Any (this
-      # narrows by value and opts out of #>> checks), so nothing upstream
-      # guarantees the attribute exists: `Types::Any.where(upcase: 'X')` is handed
-      # whatever the caller passes.
+      # Missing attributes fail the constraint instead of raising.
       return result.invalid!(errors: @error) unless result.value.respond_to?(attr_name)
       return result if value === result.value.public_send(attr_name)
 

--- a/lib/plumb/attributes.rb
+++ b/lib/plumb/attributes.rb
@@ -256,7 +256,17 @@ module Plumb
         return result if result.value.is_a?(self)
         return result.invalid(errors: MUST_BE_HASH) unless result.value.respond_to?(:to_h)
 
-        instance = new(result.value.to_h)
+        # Defining #to_h is not the same as converting to one: Array, Range and Set
+        # all define it and raise unless their elements are already pairs
+        # (`[1].to_h` => TypeError). A value that will not convert is simply not a
+        # Hash of attributes, so report that instead of raising out of #resolve.
+        begin
+          attributes = result.value.to_h
+        rescue ::TypeError, ::ArgumentError
+          return result.invalid(errors: MUST_BE_HASH)
+        end
+
+        instance = new(attributes)
         instance.valid? ? result.valid(instance) : result.invalid(instance, errors: instance.errors.to_h)
       end
 

--- a/lib/plumb/attributes.rb
+++ b/lib/plumb/attributes.rb
@@ -256,10 +256,7 @@ module Plumb
         return result if result.value.is_a?(self)
         return result.invalid(errors: MUST_BE_HASH) unless result.value.respond_to?(:to_h)
 
-        # Defining #to_h is not the same as converting to one: Array, Range and Set
-        # all define it and raise unless their elements are already pairs
-        # (`[1].to_h` => TypeError). A value that will not convert is simply not a
-        # Hash of attributes, so report that instead of raising out of #resolve.
+        # Some #to_h implementations reject malformed contents; treat that as invalid input.
         begin
           attributes = result.value.to_h
         rescue ::TypeError, ::ArgumentError

--- a/lib/plumb/composable.rb
+++ b/lib/plumb/composable.rb
@@ -122,8 +122,20 @@ module Plumb
       end
     end
 
+    # Structural equality: the same node class, around the same children.
+    #
+    # `instance_of?` rather than `is_a?`, because equality has to be SYMMETRIC and
+    # a subclass narrows behaviour without changing #children — a
+    # FilteredHashMap drops entries where its HashMap rejects the Hash, a
+    # ConcurrentArrayClass maps elements in threads. With `is_a?` a parent would
+    # equal its subclass while the subclass did not equal the parent, and since
+    # Plumb::Subtyping.subtype? and the Optimizer both short-circuit on `==`
+    # BEFORE their #value_preserving?/#identity_wrapper? guards, that lopsided
+    # answer is enough to drop the narrower node from a `&` or a `|`.
+    #
+    # A subclass that IS interchangeable with its parent overrides this.
     def ==(other)
-      other.is_a?(self.class) && other.respond_to?(:children) && other.children == children
+      other.instance_of?(self.class) && other.respond_to?(:children) && other.children == children
     end
 
     # Subtype/subset operator. `a <= b` is true when every value described by
@@ -166,6 +178,16 @@ module Plumb
       return true if self == other
 
       if Plumb::Subtyping.atomic?(self) && Plumb::Subtyping.atomic?(other)
+        # A refinement describes its BASE as well as its matcher — `Integer[1..5]`
+        # is an Integer that also falls in 1..5 — and #children holds only the
+        # matcher. So the base is checked separately, or an atomic leaf with no base
+        # of its own slips past it: `Types::Value[5.0]` matches the Range 1..5 while
+        # being no Integer at all. Constraint#subtype_of? does this for itself; this
+        # is the path ValueClass and StaticClass take.
+        if other.respond_to?(:base) && other.base && !Plumb::Subtyping.subtype?(self, other.base)
+          return false
+        end
+
         return Plumb::Subtyping.atomic_subtype?(children.first, other.children.first)
       end
 
@@ -239,6 +261,11 @@ module Plumb
         Types::Array[element_type]
       elsif callable.respond_to?(:call)
         Function.opaque(callable)
+      elsif Constraint.literal_matcher?(callable)
+        # A raw literal is a value match, the same node `Types::Any[5]` and
+        # `Types::Value[5]` build — so all three spellings are one type. A raw
+        # Class/Range/Regexp/Set is a matcher, not a value, and stays a Constraint.
+        ValueClass.new(callable)
       else
         Constraint.new(callable)
       end
@@ -572,7 +599,15 @@ module Plumb
       # matcher), matching the collapsing `AnyClass#>>` provides. Routed through
       # Constraint.narrow so stacked Range refinements intersect
       # (`Integer[0..100][10..]` == `Integer[10..100]`).
-      Constraint.narrow((is_a?(AnyClass) ? nil : self), *args)
+      base = is_a?(AnyClass) ? nil : self
+      # A BARE literal is a value match, so it gets the node that means that:
+      # `Types::Any[5]` and `Types::Value[5]` describe the same values (for a
+      # literal, `#===` IS `#==`) and now share one representation, instead of two
+      # that the type algebra related asymmetrically. A literal WITH a base stays a
+      # Constraint — `Types::Integer[5]` has an Integer check to run first.
+      return ValueClass.new(args.first) if base.nil? && args.size == 1 && Constraint.literal_matcher?(args.first)
+
+      Constraint.narrow(base, *args)
     end
 
     # Sugar over #match: a splatted list of values becomes a Set membership

--- a/lib/plumb/composable.rb
+++ b/lib/plumb/composable.rb
@@ -122,18 +122,12 @@ module Plumb
       end
     end
 
-    # Structural equality: the same node class, around the same children.
-    #
-    # `instance_of?` rather than `is_a?`, because equality has to be SYMMETRIC and
-    # a subclass narrows behaviour without changing #children — a
-    # FilteredHashMap drops entries where its HashMap rejects the Hash, a
-    # ConcurrentArrayClass maps elements in threads. With `is_a?` a parent would
-    # equal its subclass while the subclass did not equal the parent, and since
-    # Plumb::Subtyping.subtype? and the Optimizer both short-circuit on `==`
-    # BEFORE their #value_preserving?/#identity_wrapper? guards, that lopsided
-    # answer is enough to drop the narrower node from a `&` or a `|`.
-    #
-    # A subclass that IS interchangeable with its parent overrides this.
+    # Compares nodes by exact class and children. Use `instance_of?`, not `is_a?`:
+    # a subclass may change behavior without changing #children, making parent/subclass
+    # equality asymmetric. Subtyping and optimization short-circuit on `==`, so that
+    # asymmetry could discard the narrower node before its behavioral guards run.
+    # @param other [Object]
+    # @return [Boolean]
     def ==(other)
       other.instance_of?(self.class) && other.respond_to?(:children) && other.children == children
     end
@@ -178,12 +172,9 @@ module Plumb
       return true if self == other
 
       if Plumb::Subtyping.atomic?(self) && Plumb::Subtyping.atomic?(other)
-        # A refinement describes its BASE as well as its matcher — `Integer[1..5]`
-        # is an Integer that also falls in 1..5 — and #children holds only the
-        # matcher. So the base is checked separately, or an atomic leaf with no base
-        # of its own slips past it: `Types::Value[5.0]` matches the Range 1..5 while
-        # being no Integer at all. Constraint#subtype_of? does this for itself; this
-        # is the path ValueClass and StaticClass take.
+        # #children contains only the matcher, but a refinement also describes its
+        # base. Check both or an unrelated atomic value may pass on matcher overlap
+        # alone (for example, Value[5.0] against Integer[1..5]).
         if other.respond_to?(:base) && other.base && !Plumb::Subtyping.subtype?(self, other.base)
           return false
         end
@@ -262,9 +253,7 @@ module Plumb
       elsif callable.respond_to?(:call)
         Function.opaque(callable)
       elsif Constraint.literal_matcher?(callable)
-        # A raw literal is a value match, the same node `Types::Any[5]` and
-        # `Types::Value[5]` build — so all three spellings are one type. A raw
-        # Class/Range/Regexp/Set is a matcher, not a value, and stays a Constraint.
+        # Equality literals use ValueClass; broader matchers use Constraint.
         ValueClass.new(callable)
       else
         Constraint.new(callable)
@@ -600,11 +589,8 @@ module Plumb
       # Constraint.narrow so stacked Range refinements intersect
       # (`Integer[0..100][10..]` == `Integer[10..100]`).
       base = is_a?(AnyClass) ? nil : self
-      # A BARE literal is a value match, so it gets the node that means that:
-      # `Types::Any[5]` and `Types::Value[5]` describe the same values (for a
-      # literal, `#===` IS `#==`) and now share one representation, instead of two
-      # that the type algebra related asymmetrically. A literal WITH a base stays a
-      # Constraint — `Types::Integer[5]` has an Integer check to run first.
+      # A bare equality literal uses ValueClass so `Any[5]` and `Value[5]` share
+      # one subtype identity. A based literal remains a Constraint.
       return ValueClass.new(args.first) if base.nil? && args.size == 1 && Constraint.literal_matcher?(args.first)
 
       Constraint.narrow(base, *args)

--- a/lib/plumb/constraint.rb
+++ b/lib/plumb/constraint.rb
@@ -23,13 +23,12 @@ module Plumb
     # many values (and `Set#===` is `#include?` on Ruby >= 3.1).
     LITERAL_MATCHERS = [::String, ::Symbol, ::Numeric, ::TrueClass, ::FalseClass, ::NilClass].freeze
 
-    # The matcher-level form of #literal?, for the one caller that has a matcher
-    # but no instance to ask: #matcher_may_match?, which runs from the constructor
-    # BEFORE `@matcher` is assigned. Prefer #literal? on an existing Constraint.
+    # The matcher-level form of #literal? for normalization callers that do not
+    # yet have a Constraint. Prefer #literal? on an existing Constraint.
     #
     # @param matcher [#===]
     # @return [Boolean] whether `matcher` matches a single value by equality
-    def self.literal_matcher?(matcher) = LITERAL_MATCHERS.any? { |kind| matcher.is_a?(kind) }
+    def self.literal_matcher?(matcher) = SemanticMatcher.singleton?(matcher)
 
     attr_reader :children, :base, :matcher
 
@@ -46,6 +45,7 @@ module Plumb
       raise_if_incompatible!(base, matcher) if base
 
       @matcher = matcher
+      @matcher_node = SemanticMatcher.wrap(matcher)
       @base = base
       @error = error.nil? ? build_error(matcher) : (error % matcher)
       @label = matcher.is_a?(Class) ? matcher.inspect : "Constraint(#{label || @matcher.inspect})"
@@ -77,39 +77,12 @@ module Plumb
     # reuses it (see Subtyping) — an attribute constraint intersects its Range/Set
     # values just like a Constraint.
     def self.merge_matchers(a, b)
-      if a.is_a?(::Range) && b.is_a?(::Range)
-        intersect_ranges(a, b)
-      elsif a.is_a?(::Set) && b.is_a?(::Set)
-        merged = a & b
-        merged.empty? ? EMPTY : merged
-      end
-    end
+      merged = SemanticMatcher.merge(a, b)
+      return EMPTY if merged.empty?
+      return merged.node.raw if merged.merged?
 
-    # Intersection of two Ranges as a Range, `EMPTY` when provably empty (disjoint,
-    # or a single-point exclusive overlap), or `nil` when incomputable (incomparable
-    # endpoints — left to #new's incompatibility check to reject).
-    def self.intersect_ranges(a, b)
-      ab = a.begin
-      bb = b.begin
-      new_begin = ab.nil? ? bb : (bb.nil? ? ab : (ab >= bb ? ab : bb)) # greater begin (nil = -inf)
-      ae = a.end
-      be = b.end
-      new_end, new_exclude = # lesser end (nil = +inf), carrying exclusivity
-        if ae.nil? then [be, b.exclude_end?]
-        elsif be.nil? then [ae, a.exclude_end?]
-        elsif ae < be then [ae, a.exclude_end?]
-        elsif be < ae then [be, b.exclude_end?]
-        else [ae, a.exclude_end? || b.exclude_end?]
-        end
-      unless new_begin.nil? || new_end.nil?
-        return EMPTY if new_begin > new_end
-        return EMPTY if new_begin == new_end && new_exclude
-      end
-      ::Range.new(new_begin, new_end, new_exclude)
-    rescue ::ArgumentError, ::TypeError
       nil
     end
-    private_class_method :intersect_ranges
 
     # As the consumer of a `left >> self` chain:
     #   - a refinement (has a base), a Class/Module gate, or a literal matcher
@@ -121,14 +94,14 @@ module Plumb
     #     arbitrary input over a domain it cannot name, so it reports Any and opts
     #     out of the check.
     def input_type
-      return self if base || @matcher.is_a?(::Module) || literal?
+      return self if base || @matcher_node.nominal? || literal?
 
       Types::Any
     end
 
     # Whether this constraint matches a SINGLE value, by equality — so two
     # distinct ones are provably disjoint (see Subtyping#literal_value).
-    def literal? = Constraint.literal_matcher?(@matcher)
+    def literal? = @matcher_node.singleton?
 
     # @return [Boolean] whether the base and matcher are safe to deduplicate
     def idempotent? = @base.nil? || @base.idempotent?
@@ -233,24 +206,19 @@ module Plumb
     def raise_if_incompatible!(base, matcher)
       base_types = Plumb.resolve_base_types(base)
       return if base_types.empty? # unknown base (eg. a Data schema) — allow
-      return if base_types.any? { |klass| matcher_may_match?(matcher, klass) }
+      overlap = Relation.any(base_types.map { |klass| matcher_may_match_relation(matcher, klass) })
+      return unless overlap.disproven?
 
       raise Plumb::TypeError,
             "cannot refine #{base.inspect} with #{matcher.inspect}: " \
             "no #{base_types.map(&:inspect).join(' / ')} value can match it"
     end
 
-    # Could `matcher` match at least one instance of `klass`?
-    def matcher_may_match?(matcher, klass)
-      return matcher.is_a?(klass) if Constraint.literal_matcher?(matcher)
-
-      case matcher
-      when ::Module then !!((matcher <= klass) || (klass <= matcher))
-      when ::Range then (e = matcher.begin || matcher.end).nil? || e.is_a?(klass)
-      when ::Regexp then klass <= ::String || klass <= ::Symbol
-      else
-        true # proc / opaque `#===` object: domain unknown, allow
-      end
+    # Attempts to prove whether `matcher` overlaps a nominal domain. Unknown is
+    # intentionally accepted by the constructor and retained as a runtime check.
+    # @return [Relation]
+    def matcher_may_match_relation(matcher, klass)
+      SemanticMatcher.wrap(matcher).overlap(SemanticMatcher.wrap(klass))
     end
 
     def _inspect
@@ -260,16 +228,7 @@ module Plumb
     end
 
     def build_error(matcher)
-      case matcher
-      when Class # A class primitive, ex. String, Integer, etc.
-        "Must be a #{matcher}"
-      when ::String, ::Symbol, ::Numeric, ::TrueClass, ::FalseClass, ::NilClass, ::Array, ::Hash
-        "Must be equal to #{matcher}"
-      when ::Range
-        "Must be within #{matcher}"
-      else
-        "Must match #{matcher.inspect}"
-      end
+      SemanticMatcher.error_message(matcher)
     end
   end
 end

--- a/lib/plumb/constraint.rb
+++ b/lib/plumb/constraint.rb
@@ -133,8 +133,34 @@ module Plumb
     # A matcher validates without changing the value, so `Match >> Match` (of the
     # same matcher) is redundant and `#>>` collapses it — and a redundant `#|`
     # branch absorbs.
-    def idempotent? = true
-    def value_preserving? = true
+    def idempotent? = @base.nil? || @base.idempotent?
+
+    # As the consumer of a `left >> self` chain, a matcher over a CONVERTING base
+    # accepts what that base accepts: #call runs `@base` first, so
+    # `String.transform(::Integer, :to_i)[0..150]` consumes a String even though it
+    # matches against the Integer it produces. Without this it would report the
+    # produced type on both sides and read as a plain Integer refinement — letting
+    # `Types::Integer >> that` type-check, though the base rejects an Integer.
+    #
+    # A value-preserving base (the ordinary refinement, `Integer[0..100]`) keeps the
+    # default: the node itself, so the matcher is part of what a consumer must
+    # satisfy.
+    def accepted_type
+      return self unless @base && !Plumb::Subtyping.value_preserving?(@base)
+
+      Plumb::Subtyping.accepted_type(@base)
+    end
+
+    # The matcher itself changes nothing, so this preserves the value exactly when
+    # whatever it REFINES does — #call runs `@base` first.
+    #
+    # A Constraint is not always a pure check: `#[]` on a conversion re-parents into
+    # a Constraint whose base IS that conversion (see Optimizer.reduce_step), so
+    # `String.transform(::Integer, :to_i)[0..150]` converts while wearing a
+    # matcher's clothes. Reporting true for it told Optimizer.reduce_union and
+    # Subtyping.intersect they were free to drop it in favour of a subtype-equal
+    # type, which silently discarded the coercion.
+    def value_preserving? = @base.nil? || Plumb::Subtyping.value_preserving?(@base)
 
     # Structural subtyping. A matcher describes the set `base ∩ {x | matcher === x}`
     # (base = everything when nil). `self <= other` when self's set is contained in
@@ -171,9 +197,27 @@ module Plumb
         (base.is_a?(Constraint) && base.within_matcher?(m))
     end
 
+    # The caller's description of this matcher, used as its identity when the
+    # matcher itself has none (see #==).
+    protected def label = @label
+
     # Two matchers are equal when they match the same thing over the same base.
+    #
+    # A Proc matcher is compared by LABEL rather than by identity. `#check` — and
+    # every policy built on it — closes over a fresh block on each call, so two
+    # structurally identical checks hold different Proc objects and would never
+    # compare equal. The label is the caller's own description of what the check
+    # does, the same role `identity:` plays for Function. Two checks that share a
+    # message while testing different things do compare equal; describing them
+    # differently is what tells them apart.
     def ==(other)
-      other.is_a?(self.class) && other.matcher == matcher && other.base == base
+      return false unless other.instance_of?(self.class) && other.base == base
+
+      if matcher.is_a?(::Proc)
+        other.matcher.is_a?(::Proc) && other.label == label
+      else
+        other.matcher == matcher
+      end
     end
 
     def call(result)

--- a/lib/plumb/constraint.rb
+++ b/lib/plumb/constraint.rb
@@ -151,6 +151,19 @@ module Plumb
       Plumb::Subtyping.accepted_type(@base)
     end
 
+    # A matcher over a CONVERTING base is itself a conversion, and the relation
+    # identifies a conversion by what it PRODUCES (see Composable#subtype_identity).
+    # `String.transform(::Integer, :to_i)[0..150]` produces `Integer[0..150]`: the
+    # base's output, narrowed by this matcher. Without projecting, such a node is
+    # compared as though it accepted Integers, which it does not — it consumes
+    # Strings.
+    def subtype_identity
+      return self if @base.nil? || Plumb::Subtyping.value_preserving?(@base)
+
+      produced = Plumb::Subtyping.resolved_output(@base)
+      produced.equal?(@base) ? self : Constraint.narrow(produced, @matcher)
+    end
+
     # The matcher itself changes nothing, so this preserves the value exactly when
     # whatever it REFINES does — #call runs `@base` first.
     #

--- a/lib/plumb/constraint.rb
+++ b/lib/plumb/constraint.rb
@@ -130,33 +130,21 @@ module Plumb
     # distinct ones are provably disjoint (see Subtyping#literal_value).
     def literal? = Constraint.literal_matcher?(@matcher)
 
-    # A matcher validates without changing the value, so `Match >> Match` (of the
-    # same matcher) is redundant and `#>>` collapses it — and a redundant `#|`
-    # branch absorbs.
+    # @return [Boolean] whether the base and matcher are safe to deduplicate
     def idempotent? = @base.nil? || @base.idempotent?
 
-    # As the consumer of a `left >> self` chain, a matcher over a CONVERTING base
-    # accepts what that base accepts: #call runs `@base` first, so
-    # `String.transform(::Integer, :to_i)[0..150]` consumes a String even though it
-    # matches against the Integer it produces. Without this it would report the
-    # produced type on both sides and read as a plain Integer refinement — letting
-    # `Types::Integer >> that` type-check, though the base rejects an Integer.
-    #
-    # A value-preserving base (the ordinary refinement, `Integer[0..100]`) keeps the
-    # default: the node itself, so the matcher is part of what a consumer must
-    # satisfy.
+    # A converting base runs before the matcher, so this constraint consumes what
+    # the base accepts. Pure refinements accept themselves.
+    # @return [Composable]
     def accepted_type
       return self unless @base && !Plumb::Subtyping.value_preserving?(@base)
 
       Plumb::Subtyping.accepted_type(@base)
     end
 
-    # A matcher over a CONVERTING base is itself a conversion, and the relation
-    # identifies a conversion by what it PRODUCES (see Composable#subtype_identity).
-    # `String.transform(::Integer, :to_i)[0..150]` produces `Integer[0..150]`: the
-    # base's output, narrowed by this matcher. Without projecting, such a node is
-    # compared as though it accepted Integers, which it does not — it consumes
-    # Strings.
+    # Projects a matcher over a conversion onto the narrowed output type. Without
+    # this, subtype checks would treat the node as consuming the value it produces.
+    # @return [Composable]
     def subtype_identity
       return self if @base.nil? || Plumb::Subtyping.value_preserving?(@base)
 
@@ -164,15 +152,9 @@ module Plumb
       produced.equal?(@base) ? self : Constraint.narrow(produced, @matcher)
     end
 
-    # The matcher itself changes nothing, so this preserves the value exactly when
-    # whatever it REFINES does — #call runs `@base` first.
-    #
-    # A Constraint is not always a pure check: `#[]` on a conversion re-parents into
-    # a Constraint whose base IS that conversion (see Optimizer.reduce_step), so
-    # `String.transform(::Integer, :to_i)[0..150]` converts while wearing a
-    # matcher's clothes. Reporting true for it told Optimizer.reduce_union and
-    # Subtyping.intersect they were free to drop it in favour of a subtype-equal
-    # type, which silently discarded the coercion.
+    # A constraint may wrap a converting base; treating it as a pure filter would
+    # let reductions discard that conversion.
+    # @return [Boolean] whether the base and matcher preserve the input value
     def value_preserving? = @base.nil? || Plumb::Subtyping.value_preserving?(@base)
 
     # Structural subtyping. A matcher describes the set `base ∩ {x | matcher === x}`
@@ -210,19 +192,13 @@ module Plumb
         (base.is_a?(Constraint) && base.within_matcher?(m))
     end
 
-    # The caller's description of this matcher, used as its identity when the
-    # matcher itself has none (see #==).
+    # Identity label for matchers without structural equality.
     protected def label = @label
 
-    # Two matchers are equal when they match the same thing over the same base.
-    #
-    # A Proc matcher is compared by LABEL rather than by identity. `#check` — and
-    # every policy built on it — closes over a fresh block on each call, so two
-    # structurally identical checks hold different Proc objects and would never
-    # compare equal. The label is the caller's own description of what the check
-    # does, the same role `identity:` plays for Function. Two checks that share a
-    # message while testing different things do compare equal; describing them
-    # differently is what tells them apart.
+    # Compares matchers and bases. Fresh Procs lack structural equality, so Proc
+    # matchers use their caller-supplied label as stable identity.
+    # @param other [Object]
+    # @return [Boolean]
     def ==(other)
       return false unless other.instance_of?(self.class) && other.base == base
 

--- a/lib/plumb/deferred.rb
+++ b/lib/plumb/deferred.rb
@@ -13,17 +13,9 @@ module Plumb
       # freeze
     end
 
-    # Identified by object identity. A Deferred stands in for a type it has not
-    # materialized yet, so it exposes no #children — structural equality would
-    # therefore compare two empty child lists and find EVERY Deferred equal to
-    # every other. Forcing #type here to compare what they materialize is not an
-    # option either: on a self-referential type (the reason Deferred exists) that
-    # recurses forever.
-    #
-    # Nothing is lost by being conservative here. Plumb::Subtyping.subtype?
-    # unwraps a Deferred and relates what it materializes, breaking cycles
-    # coinductively — so the relation still sees through two distinct Deferreds
-    # that describe the same type, even though `==` does not.
+    # Deferred nodes use identity equality to avoid materializing recursive types.
+    # @param other [Object]
+    # @return [Boolean]
     def ==(other) = equal?(other)
 
     def call(result)
@@ -45,4 +37,3 @@ module Plumb
     end
   end
 end
-

--- a/lib/plumb/deferred.rb
+++ b/lib/plumb/deferred.rb
@@ -13,6 +13,19 @@ module Plumb
       # freeze
     end
 
+    # Identified by object identity. A Deferred stands in for a type it has not
+    # materialized yet, so it exposes no #children — structural equality would
+    # therefore compare two empty child lists and find EVERY Deferred equal to
+    # every other. Forcing #type here to compare what they materialize is not an
+    # option either: on a self-referential type (the reason Deferred exists) that
+    # recurses forever.
+    #
+    # Nothing is lost by being conservative here. Plumb::Subtyping.subtype?
+    # unwraps a Deferred and relates what it materializes, breaking cycles
+    # coinductively — so the relation still sees through two distinct Deferreds
+    # that describe the same type, even though `==` does not.
+    def ==(other) = equal?(other)
+
     def call(result)
       type.call(result)
     end

--- a/lib/plumb/function.rb
+++ b/lib/plumb/function.rb
@@ -185,17 +185,17 @@ module Plumb
       result.map(@input_type).map(@fn).map(@output_type)
     end
 
-    # This node's fn with its own output check applied, as one step — what a fused
-    # node runs in place of `@fn` so the check survives the seam. @see #fuse_with
+    # Wraps this function with its output check for fusion.
+    # @return [Proc]
+    # @see #fuse_with
     protected def fn_with_output_check
       fn = @fn
       out = @output_type
       ->(result) { result.map(fn).map(out) }
     end
 
-    # Fuse `self >> other` into a single Function running both fns: `(A -> B) >>
-    # (B -> C)` becomes `(A -> C)`, with one runtime check dropped at the
-    # boundary — `other`'s input check, which subsumption proves redundant.
+    # Fuses compatible functions while retaining this function's output check;
+    # declared subtype compatibility does not prove what the callable returns.
     # Returns nil (no fusion) unless:
     #   - both #calls are the standard input->fn->output mapping (see #fusible?);
     #   - what self produces is a DIRECT subtype of what other declares as
@@ -205,18 +205,13 @@ module Plumb
     #   - the dropped check is value-preserving: a coercing input type changes the
     #     value, so it must keep running.
     #
-    # What is NOT dropped is self's own output check. Subsumption proves the
-    # DECLARED output sits within what `other` accepts; it says nothing about what
-    # `fn1` actually returns, and #call validates that for exactly this reason (a
-    # wrong return value becomes an invalid Result, not silent corruption). Dropping
-    # it would let a fn that returns the wrong type pass at a seam while failing on
-    # its own — so composing would CHANGE validity.
+    # @param other [Function]
+    # @return [Function, nil]
     def fuse_with(other)
       return nil unless fusable_step? && other.fusable_step?
       return nil unless Plumb::Subtyping.subtype?(@output_type, other.input_type)
       return nil unless Plumb::Subtyping.value_preserving?(other.input_type)
-      # A converting output type stays an unfused And, so the value it produces is
-      # visible between the two nodes rather than buried inside one.
+      # Converting output checks must remain explicit between nodes.
       return nil unless !checks_output? || Plumb::Subtyping.value_preserving?(@output_type)
 
       fn1 = checks_output? ? fn_with_output_check : @fn

--- a/lib/plumb/function.rb
+++ b/lib/plumb/function.rb
@@ -185,25 +185,41 @@ module Plumb
       result.map(@input_type).map(@fn).map(@output_type)
     end
 
-    # Fuse `self >> other` into a single Function running both fns, dropping
-    # the redundant runtime checks at the boundary: `(A -> B) >> (B -> C)`
-    # becomes `(A -> C)` — the intermediate `B` was proven here, at build time.
+    # This node's fn with its own output check applied, as one step — what a fused
+    # node runs in place of `@fn` so the check survives the seam. @see #fuse_with
+    protected def fn_with_output_check
+      fn = @fn
+      out = @output_type
+      ->(result) { result.map(fn).map(out) }
+    end
+
+    # Fuse `self >> other` into a single Function running both fns: `(A -> B) >>
+    # (B -> C)` becomes `(A -> C)`, with one runtime check dropped at the
+    # boundary — `other`'s input check, which subsumption proves redundant.
     # Returns nil (no fusion) unless:
     #   - both #calls are the standard input->fn->output mapping (see #fusible?);
     #   - what self produces is a DIRECT subtype of what other declares as
     #     input. check_composable! is looser — it relaxes container fields via
     #     accepted_type (the `encode >> decode` case), and there other's input
     #     check does real per-field work and must keep running;
-    #   - the dropped checks are value-preserving: a coercing boundary type
-    #     changes the value, so it must keep running. self's output check needs
-    #     this only when it runs at all (see TypedStep#checks_output?).
+    #   - the dropped check is value-preserving: a coercing input type changes the
+    #     value, so it must keep running.
+    #
+    # What is NOT dropped is self's own output check. Subsumption proves the
+    # DECLARED output sits within what `other` accepts; it says nothing about what
+    # `fn1` actually returns, and #call validates that for exactly this reason (a
+    # wrong return value becomes an invalid Result, not silent corruption). Dropping
+    # it would let a fn that returns the wrong type pass at a seam while failing on
+    # its own — so composing would CHANGE validity.
     def fuse_with(other)
       return nil unless fusable_step? && other.fusable_step?
       return nil unless Plumb::Subtyping.subtype?(@output_type, other.input_type)
       return nil unless Plumb::Subtyping.value_preserving?(other.input_type)
+      # A converting output type stays an unfused And, so the value it produces is
+      # visible between the two nodes rather than buried inside one.
       return nil unless !checks_output? || Plumb::Subtyping.value_preserving?(@output_type)
 
-      fn1 = @fn
+      fn1 = checks_output? ? fn_with_output_check : @fn
       fn2 = other.fn
       # Rebuild as one of the two standard classes, not `other.class`: a node is
       # fusable because it kept #call, which says nothing about its constructor,

--- a/lib/plumb/hash_class.rb
+++ b/lib/plumb/hash_class.rb
@@ -15,7 +15,8 @@ module Plumb
 
     attr_reader :_schema
 
-    def initialize(schema: BLANK_HASH)
+    def initialize(schema: BLANK_HASH, closed: false)
+      @closed = closed
       @_schema = wrap_keys_and_values(schema)
       # Partition once (the instance is frozen): literal keys use exact lookup in
       # #call; matcher keys (typed keys and the `_` catch-all) are matched against
@@ -30,6 +31,28 @@ module Plumb
     # The `_` catch-all value type (what every otherwise-unmatched key must be),
     # or nil when the schema is closed. See #call / #&.
     attr_reader :catch_all_type
+
+    # Does this record carry ONLY the keys it declares?
+    #
+    # False for a schema describing INCOMING data: extra keys are ignored rather
+    # than forbidden, so the hashes it describes may carry an unconstrained tail —
+    # which is what makes #subtype_of? strict. True for the same record read as a
+    # produced VALUE, since #call emits nothing it did not declare. See #closed.
+    def closed? = @closed
+
+    # This record read as a produced value. Consulted by
+    # Plumb::Subtyping.check_composable!, which asks what a step EMITS, not what a
+    # schema describes.
+    #
+    # Only meaningful when every key is literal: a matcher key — a typed key or the
+    # `_` catch-all — passes through key names it never declared, so what it emits
+    # still has a tail. Those (and the any-Hash top, which returns its input
+    # untouched) answer for themselves.
+    def closed
+      return self if @closed || _schema.empty? || !@matcher_fields.empty?
+
+      self.class.new(schema: _schema, closed: true)
+    end
 
     # The literal (Symbol/String) entries of the schema.
     attr_reader :literal_fields
@@ -102,8 +125,15 @@ module Plumb
     # meet iff the OTHER side permits it — either it names the key too, or it has a
     # catch-all that admits it. So `Hash[a: String, _: Any] & Hash[a: String, b:
     # Integer] == Hash[a: String, b: Integer]` (the right's `b` is admitted by the
-    # left's `_`, met with Any). The result carries a catch-all only when BOTH
-    # sides do (`Tₐ & T_b`).
+    # left's `_`, met with Any).
+    #
+    # The result keeps a catch-all whenever either side CONSTRAINS the tail: both
+    # sides met (`Tₐ & T_b`), or the lone one on its own. A closed side merely drops
+    # the extra keys (see #call) while the open side still validates them, so
+    # `Hash[_: Integer] & Hash[a: Integer]` goes on requiring Integer values
+    # throughout — dropping the catch-all there would admit `{a: 1, b: 'x'}`, which
+    # the left rejects. An `Any` catch-all constrains nothing and is left out, so
+    # the meet of two ordinary schemas stays the shared key set.
     #
     # Against anything that is not a HashClass there is no key intersection: defer
     # to the generic Composable#& (Subtyping.intersect), which yields Types::Never
@@ -139,7 +169,14 @@ module Plumb
         result[their_key] = their_field & my_catch if my_catch
       end
 
-      result[Key.new(Types::Any)] = my_catch & their_catch if my_catch && their_catch
+      # An arbitrary tail must satisfy every side that CONSTRAINS it. With one
+      # catch-all its type stands alone: the closed side merely drops the extra keys
+      # (see #call), while this side still validates them — so
+      # `Hash[_: Integer] & Hash[a: Integer]` keeps requiring Integer values
+      # throughout. An `Any` catch-all constrains nothing and is left out, so the
+      # meet of two schemas stays the shared key set.
+      tail = my_catch && their_catch ? my_catch & their_catch : (my_catch || their_catch)
+      result[Key.new(Types::Any)] = tail if tail && !tail.is_a?(AnyClass)
 
       return Types::Never if result.empty? # two closed schemas that share nothing
 
@@ -297,7 +334,7 @@ module Plumb
       return false if _schema.empty?
       return true if other._schema.empty?
 
-      named_keys_ok?(other) && carried_keys_ok?(other)
+      named_keys_ok?(other) && carried_keys_ok?(other) && tail_ok?(other)
     end
 
     # As a consumer, this Hash accepts each field relaxed to what *that* field
@@ -358,10 +395,44 @@ module Plumb
           Plumb::Subtyping.subtype?(mine_field, other_field) &&
             (other_key.optional? || !mine_key.optional?)
         else
-          other_key.optional? &&
-            matcher_fields_matching(other_key).all? { |f| Plumb::Subtyping.subtype?(f, other_field) }
+          # `self` never names it, so its values may carry that key holding whatever
+          # `self` guarantees for keys it does not name — which is NOTHING unless a
+          # matcher key or the `_` catch-all claims it. `other` would then reject a
+          # value `self` admits, so this is not a subtype.
+          # A closed record simply never carries the key, and `other` allows it to be
+          # missing. An open one may carry it holding anything, so it has to promise.
+          other_key.optional? && (closed? || promises?(guarantee_for(other_key.to_key), other_field))
         end
       end
+    end
+
+    # What `self` promises about a key it does not literally declare: the field of
+    # the first matcher key that claims it (#call is first-match-wins), which
+    # includes the `_` catch-all. nil when nothing claims it — the key is then
+    # unconstrained and may hold anything.
+    def guarantee_for(key_name)
+      @matcher_fields.find { |mk, _| mk.match?(key_name) }&.last
+    end
+
+    # `other`'s MATCHER keys — its typed keys and its `_` catch-all — constrain keys
+    # it does not name, which is exactly the open tail `self` may carry. So `self`
+    # has to promise the same thing about that tail, and only a catch-all of its own
+    # can. Without one the tail is unconstrained and `other` would reject values
+    # `self` admits.
+    def tail_ok?(other)
+      return true if closed? # no tail for `other`'s matcher keys to constrain
+
+      other.matcher_fields.all? { |_k, f| promises?(catch_all_type, f) }
+    end
+
+    # Does what `self` promises for an unnamed key — possibly nothing — satisfy what
+    # `other` wants there? A wanted type of `Any` constrains nothing, so an absent
+    # promise still satisfies it: that is what keeps a closed Hash a subtype of the
+    # same Hash opened with `_: Any`.
+    def promises?(guaranteed, wanted)
+      return true if wanted.is_a?(AnyClass)
+
+      !guaranteed.nil? && Plumb::Subtyping.subtype?(guaranteed, wanted)
     end
 
     # Every key `self` can carry that `other` does not name has to satisfy whichever
@@ -389,11 +460,6 @@ module Plumb
       end
     end
 
-    # The value types `self` can carry under the name `key` via its MATCHER keys.
-    def matcher_fields_matching(key)
-      @matcher_fields.filter_map { |mk, field| field if mk.match?(key.to_key) }
-    end
-
     # Could one Ruby key be claimed by both of these keys? Exact whenever either
     # side is literal. Two matchers are assumed to overlap: their domains are
     # arbitrary `#===` matchers and cannot be compared in general, so the caller
@@ -408,6 +474,11 @@ module Plumb
 
     def hashmap_subtype?(other)
       return false if _schema.empty?
+      # A map constrains every key and value it carries, so a record sits below one
+      # only when it leaves no unconstrained tail: either it is read as a produced
+      # value (see #closed), or it has a catch-all — and then the loop below still
+      # has to place that catch-all's Any key matcher inside the map's key type.
+      return false unless closed? || catch_all_type
 
       key_type, value_type = other.children
       _schema.all? do |key, field|

--- a/lib/plumb/hash_class.rb
+++ b/lib/plumb/hash_class.rb
@@ -290,32 +290,14 @@ module Plumb
       return hashmap_subtype?(other) if other.is_a?(HashMap)
       return false unless other.is_a?(HashClass)
 
-      # Depth/width over `other`'s named (literal) keys, as before.
-      literal_ok = other.literal_fields.all? do |other_key, other_field|
-        mine_key, mine_field = _schema.find { |k, _| k.eql?(other_key) }
-        if mine_field
-          Plumb::Subtyping.subtype?(mine_field, other_field) &&
-            (other_key.optional? || !mine_key.optional?)
-        else
-          other_key.optional?
-        end
-      end
-      return false unless literal_ok
+      # An empty schema is the "any Hash" top, and #call returns the input
+      # UNTOUCHED for it (there are no fields to project through) — so it can carry
+      # any key holding any value. Nothing narrower describes that. The mirror of
+      # the guard in #hashmap_subtype?.
+      return false if _schema.empty?
+      return true if other._schema.empty?
 
-      # Catch-all covariance: if `other` accepts an arbitrary tail `Tᵒ`, every key
-      # `self` may carry that `other` does not name must be a subtype of `Tᵒ` —
-      # `self`'s own catch-all `Tˢ`, and any literal key of `self` not named by
-      # `other`. If `other` is closed, no extra restriction (a closed consumer
-      # drops unknown keys, so width subtyping is unaffected — as before).
-      if (oc = other.catch_all_type)
-        return false if catch_all_type && !Plumb::Subtyping.subtype?(catch_all_type, oc)
-
-        literal_fields.all? do |mk, mf|
-          other._schema.key?(mk) || Plumb::Subtyping.subtype?(mf, oc)
-        end
-      else
-        true
-      end
+      named_keys_ok?(other) && carried_keys_ok?(other)
     end
 
     # As a consumer, this Hash accepts each field relaxed to what *that* field
@@ -361,6 +343,69 @@ module Plumb
     # A catch-all `_: T` carries the Any key matcher, so `Any <= key_type` fails
     # unless the map accepts any key — an open Hash is NOT a subtype of a
     # Symbol-keyed map.
+    # Depth and width over the keys `other` NAMES. `self` must supply each one as a
+    # required key of a subtype; a key `other` makes optional may be missing.
+    #
+    # "Missing" is not the same as "never present", which is why the optional case
+    # still has work to do: a matcher key of `self` (a typed key, or the `_`
+    # catch-all) can carry that name through with a value of its own type, and
+    # `other` then checks it. `Hash[_: Any]` does not satisfy `Hash[name?: String]`
+    # — it happily passes `{name: 1}` along.
+    def named_keys_ok?(other)
+      other.literal_fields.all? do |other_key, other_field|
+        mine_key, mine_field = _schema.find { |k, _| k.eql?(other_key) }
+        if mine_field
+          Plumb::Subtyping.subtype?(mine_field, other_field) &&
+            (other_key.optional? || !mine_key.optional?)
+        else
+          other_key.optional? &&
+            matcher_fields_matching(other_key).all? { |f| Plumb::Subtyping.subtype?(f, other_field) }
+        end
+      end
+    end
+
+    # Every key `self` can carry that `other` does not name has to satisfy whichever
+    # of `other`'s matcher keys claims it — its typed keys and its `_` catch-all.
+    # A key none of them matches is dropped by `other`'s #call (the non-inclusive
+    # default), so it constrains nothing: that is what makes width subtyping work
+    # against a closed record.
+    #
+    # Covers `self`'s matcher keys as well as its literal ones. A typed key like
+    # `String[/^id_/] => String` carries values just as a named key does, and
+    # `other`'s catch-all applies to them the same way.
+    def carried_keys_ok?(other)
+      _schema.all? do |mine_key, mine_field|
+        theirs = other._schema.find { |ok, _| ok.eql?(mine_key) }
+        if theirs
+          # The same key on both sides. Literal keys were already related by
+          # #named_keys_ok?; a matcher key still needs its depth checked.
+          mine_key.literal? || Plumb::Subtyping.subtype?(mine_field, theirs.last)
+        else
+          other.matcher_fields.all? do |other_key, other_field|
+            !keys_may_overlap?(mine_key, other_key) ||
+              Plumb::Subtyping.subtype?(mine_field, other_field)
+          end
+        end
+      end
+    end
+
+    # The value types `self` can carry under the name `key` via its MATCHER keys.
+    def matcher_fields_matching(key)
+      @matcher_fields.filter_map { |mk, field| field if mk.match?(key.to_key) }
+    end
+
+    # Could one Ruby key be claimed by both of these keys? Exact whenever either
+    # side is literal. Two matchers are assumed to overlap: their domains are
+    # arbitrary `#===` matchers and cannot be compared in general, so the caller
+    # demands the depth relation rather than assume they are disjoint.
+    def keys_may_overlap?(mine, theirs)
+      return mine.eql?(theirs) if mine.literal? && theirs.literal?
+      return theirs.match?(mine.to_key) if mine.literal?
+      return mine.match?(theirs.to_key) if theirs.literal?
+
+      true
+    end
+
     def hashmap_subtype?(other)
       return false if _schema.empty?
 

--- a/lib/plumb/hash_class.rb
+++ b/lib/plumb/hash_class.rb
@@ -15,6 +15,8 @@ module Plumb
 
     attr_reader :_schema
 
+    # @param schema [Hash] field definitions keyed by literal or matcher keys
+    # @param closed [Boolean] whether values contain only declared keys
     def initialize(schema: BLANK_HASH, closed: false)
       @closed = closed
       @_schema = wrap_keys_and_values(schema)
@@ -32,22 +34,14 @@ module Plumb
     # or nil when the schema is closed. See #call / #&.
     attr_reader :catch_all_type
 
-    # Does this record carry ONLY the keys it declares?
-    #
-    # False for a schema describing INCOMING data: extra keys are ignored rather
-    # than forbidden, so the hashes it describes may carry an unconstrained tail —
-    # which is what makes #subtype_of? strict. True for the same record read as a
-    # produced VALUE, since #call emits nothing it did not declare. See #closed.
+    # Input schemas are open because #call ignores extra keys; produced literal-key
+    # records are closed because #call emits only declared keys.
+    # @return [Boolean] whether values contain only declared keys
     def closed? = @closed
 
-    # This record read as a produced value. Consulted by
-    # Plumb::Subtyping.check_composable!, which asks what a step EMITS, not what a
-    # schema describes.
-    #
-    # Only meaningful when every key is literal: a matcher key — a typed key or the
-    # `_` catch-all — passes through key names it never declared, so what it emits
-    # still has a tail. Those (and the any-Hash top, which returns its input
-    # untouched) answer for themselves.
+    # Returns the closed form emitted by a literal-key schema.
+    # Matcher-key and empty schemas remain open because they can pass unknown keys.
+    # @return [HashClass]
     def closed
       return self if @closed || _schema.empty? || !@matcher_fields.empty?
 
@@ -100,44 +94,11 @@ module Plumb
       self.class.new(schema: merge_rightmost_keys(_schema, other_schema))
     end
 
-    # Two Hash schemas are treated as maps: the result keeps the keys present in
-    # BOTH, and each shared key's field type is itself intersected (`self`'s field
-    # `&` `other`'s field). So a field may narrow — `Hash[age: Integer[1..20]] &
-    # Hash[age: Integer[0..10]]` == `Hash[age: Integer[1..10]]` — or collapse to
-    # `Never` when the two field types are disjoint (`Hash[age: Integer[1..5]] &
-    # Hash[age: Integer[10..20]]` == `Hash[age: Never]`). Key optionality is taken
-    # from `other`.
-    #
-    # Two non-empty schemas that share NO keys have nothing in common, so the
-    # intersection is empty ⇒ `Types::Never`. (Pragmatic map reading: under strict
-    # width subtyping a value like `{a: 1, b: "x"}` inhabits both `Hash[a: Integer]`
-    # and `Hash[b: String]`, so their value-set meet is non-empty — but for maps we
-    # treat "no common keys" as no intersection.) The empty-schema Hash
-    # (`Types::Hash`) is the "any Hash" top of the family and the IDENTITY of
-    # intersection, NOT an empty overlap: `Hash[] & X == X`.
-    #
-    # A required shared key whose field is `Never` makes the hash effectively
-    # uninhabitable, but is kept structurally as `Hash[key: Never]` rather than
-    # collapsed to a whole-hash `Never` — an optional such key would still admit
-    # hashes that omit it, so a blanket collapse would be unsound.
-    #
-    # A `_` catch-all widens what survives: a key present on ONE side survives the
-    # meet iff the OTHER side permits it — either it names the key too, or it has a
-    # catch-all that admits it. So `Hash[a: String, _: Any] & Hash[a: String, b:
-    # Integer] == Hash[a: String, b: Integer]` (the right's `b` is admitted by the
-    # left's `_`, met with Any).
-    #
-    # The result keeps a catch-all whenever either side CONSTRAINS the tail: both
-    # sides met (`Tₐ & T_b`), or the lone one on its own. A closed side merely drops
-    # the extra keys (see #call) while the open side still validates them, so
-    # `Hash[_: Integer] & Hash[a: Integer]` goes on requiring Integer values
-    # throughout — dropping the catch-all there would admit `{a: 1, b: 'x'}`, which
-    # the left rejects. An `Any` catch-all constrains nothing and is left out, so
-    # the meet of two ordinary schemas stays the shared key set.
-    #
-    # Against anything that is not a HashClass there is no key intersection: defer
-    # to the generic Composable#& (Subtyping.intersect), which yields Types::Never
-    # for a provably-disjoint type (eg. `Hash & Integer`).
+    # Intersects shared fields and any fields admitted by the other schema's
+    # catch-all. The empty schema is the Hash top; disjoint non-empty schemas
+    # produce Never. Non-Hash operands use the generic intersection.
+    # @param other [Object]
+    # @return [HashClass, Composable]
     def &(other)
       # Route through the intersection hook (not bare Composable.wrap) so a
       # context-resolving operand — eg. an Encoder class — orients against this
@@ -169,12 +130,9 @@ module Plumb
         result[their_key] = their_field & my_catch if my_catch
       end
 
-      # An arbitrary tail must satisfy every side that CONSTRAINS it. With one
-      # catch-all its type stands alone: the closed side merely drops the extra keys
-      # (see #call), while this side still validates them — so
-      # `Hash[_: Integer] & Hash[a: Integer]` keeps requiring Integer values
-      # throughout. An `Any` catch-all constrains nothing and is left out, so the
-      # meet of two schemas stays the shared key set.
+      # Preserve every non-Any constraint on unmatched keys. A closed side may drop
+      # extras, but an open side still validates them; dropping its lone catch-all
+      # would admit values that the open side rejects.
       tail = my_catch && their_catch ? my_catch & their_catch : (my_catch || their_catch)
       result[Key.new(Types::Any)] = tail if tail && !tail.is_a?(AnyClass)
 
@@ -327,10 +285,7 @@ module Plumb
       return hashmap_subtype?(other) if other.is_a?(HashMap)
       return false unless other.is_a?(HashClass)
 
-      # An empty schema is the "any Hash" top, and #call returns the input
-      # UNTOUCHED for it (there are no fields to project through) — so it can carry
-      # any key holding any value. Nothing narrower describes that. The mirror of
-      # the guard in #hashmap_subtype?.
+      # The unconstrained Hash is the top of this family, never a narrower subtype.
       return false if _schema.empty?
       return true if other._schema.empty?
 
@@ -374,20 +329,7 @@ module Plumb
 
     private
 
-    # A structured Hash is a subtype of a `key_type => value_type` map when every
-    # entry fits: each key (literal name, or a matcher/catch-all's key matcher) is
-    # a subtype of `key_type`, and each value type is a subtype of `value_type`.
-    # A catch-all `_: T` carries the Any key matcher, so `Any <= key_type` fails
-    # unless the map accepts any key — an open Hash is NOT a subtype of a
-    # Symbol-keyed map.
-    # Depth and width over the keys `other` NAMES. `self` must supply each one as a
-    # required key of a subtype; a key `other` makes optional may be missing.
-    #
-    # "Missing" is not the same as "never present", which is why the optional case
-    # still has work to do: a matcher key of `self` (a typed key, or the `_`
-    # catch-all) can carry that name through with a value of its own type, and
-    # `other` then checks it. `Hash[_: Any]` does not satisfy `Hash[name?: String]`
-    # — it happily passes `{name: 1}` along.
+    # Checks required keys and the types of optional keys that self may carry.
     def named_keys_ok?(other)
       other.literal_fields.all? do |other_key, other_field|
         mine_key, mine_field = _schema.find { |k, _| k.eql?(other_key) }
@@ -395,61 +337,39 @@ module Plumb
           Plumb::Subtyping.subtype?(mine_field, other_field) &&
             (other_key.optional? || !mine_key.optional?)
         else
-          # `self` never names it, so its values may carry that key holding whatever
-          # `self` guarantees for keys it does not name — which is NOTHING unless a
-          # matcher key or the `_` catch-all claims it. `other` would then reject a
-          # value `self` admits, so this is not a subtype.
-          # A closed record simply never carries the key, and `other` allows it to be
-          # missing. An open one may carry it holding anything, so it has to promise.
+          # "Optional" does not mean impossible: matcher keys or a catch-all may
+          # still carry this name. Closed records omit it; open records must
+          # constrain any value they can carry there.
           other_key.optional? && (closed? || promises?(guarantee_for(other_key.to_key), other_field))
         end
       end
     end
 
-    # What `self` promises about a key it does not literally declare: the field of
-    # the first matcher key that claims it (#call is first-match-wins), which
-    # includes the `_` catch-all. nil when nothing claims it — the key is then
-    # unconstrained and may hold anything.
+    # Returns the first matcher field that claims an undeclared key.
     def guarantee_for(key_name)
       @matcher_fields.find { |mk, _| mk.match?(key_name) }&.last
     end
 
-    # `other`'s MATCHER keys — its typed keys and its `_` catch-all — constrain keys
-    # it does not name, which is exactly the open tail `self` may carry. So `self`
-    # has to promise the same thing about that tail, and only a catch-all of its own
-    # can. Without one the tail is unconstrained and `other` would reject values
-    # `self` admits.
+    # Checks that self's open tail satisfies every matcher field in other.
     def tail_ok?(other)
       return true if closed? # no tail for `other`'s matcher keys to constrain
 
       other.matcher_fields.all? { |_k, f| promises?(catch_all_type, f) }
     end
 
-    # Does what `self` promises for an unnamed key — possibly nothing — satisfy what
-    # `other` wants there? A wanted type of `Any` constrains nothing, so an absent
-    # promise still satisfies it: that is what keeps a closed Hash a subtype of the
-    # same Hash opened with `_: Any`.
+    # Tests whether an optional guarantee satisfies a requested field type.
     def promises?(guaranteed, wanted)
       return true if wanted.is_a?(AnyClass)
 
       !guaranteed.nil? && Plumb::Subtyping.subtype?(guaranteed, wanted)
     end
 
-    # Every key `self` can carry that `other` does not name has to satisfy whichever
-    # of `other`'s matcher keys claims it — its typed keys and its `_` catch-all.
-    # A key none of them matches is dropped by `other`'s #call (the non-inclusive
-    # default), so it constrains nothing: that is what makes width subtyping work
-    # against a closed record.
-    #
-    # Covers `self`'s matcher keys as well as its literal ones. A typed key like
-    # `String[/^id_/] => String` carries values just as a named key does, and
-    # `other`'s catch-all applies to them the same way.
+    # Checks every carried key against overlapping matcher fields in other.
     def carried_keys_ok?(other)
       _schema.all? do |mine_key, mine_field|
         theirs = other._schema.find { |ok, _| ok.eql?(mine_key) }
         if theirs
-          # The same key on both sides. Literal keys were already related by
-          # #named_keys_ok?; a matcher key still needs its depth checked.
+          # named_keys_ok? already checked literal fields.
           mine_key.literal? || Plumb::Subtyping.subtype?(mine_field, theirs.last)
         else
           other.matcher_fields.all? do |other_key, other_field|
@@ -460,10 +380,7 @@ module Plumb
       end
     end
 
-    # Could one Ruby key be claimed by both of these keys? Exact whenever either
-    # side is literal. Two matchers are assumed to overlap: their domains are
-    # arbitrary `#===` matchers and cannot be compared in general, so the caller
-    # demands the depth relation rather than assume they are disjoint.
+    # Tests literal overlap exactly; assumes two arbitrary matchers may overlap.
     def keys_may_overlap?(mine, theirs)
       return mine.eql?(theirs) if mine.literal? && theirs.literal?
       return theirs.match?(mine.to_key) if mine.literal?
@@ -474,10 +391,7 @@ module Plumb
 
     def hashmap_subtype?(other)
       return false if _schema.empty?
-      # A map constrains every key and value it carries, so a record sits below one
-      # only when it leaves no unconstrained tail: either it is read as a produced
-      # value (see #closed), or it has a catch-all — and then the loop below still
-      # has to place that catch-all's Any key matcher inside the map's key type.
+      # Open records need a catch-all to constrain every map entry.
       return false unless closed? || catch_all_type
 
       key_type, value_type = other.children

--- a/lib/plumb/hash_map.rb
+++ b/lib/plumb/hash_map.rb
@@ -25,9 +25,14 @@ module Plumb
     def subtype_of?(other)
       if other.is_a?(HashClass)
         return true if other._schema.empty?
-        return false unless other.only_catch_all?
 
-        return Plumb::Subtyping.subtype?(@value_type, other.catch_all_type)
+        # A map validates EVERY entry (#call iterates the whole hash), so it has no
+        # unconstrained tail: whatever `other` asks of any key, @value_type already
+        # guarantees. What a map does NOT promise is that any particular key is
+        # PRESENT, so a key `other` requires can never be satisfied.
+        return false if other.literal_fields.any? { |k, _| !k.optional? }
+
+        return other._schema.all? { |_k, field| Plumb::Subtyping.subtype?(@value_type, field) }
       end
 
       super

--- a/lib/plumb/hash_map.rb
+++ b/lib/plumb/hash_map.rb
@@ -26,10 +26,7 @@ module Plumb
       if other.is_a?(HashClass)
         return true if other._schema.empty?
 
-        # A map validates EVERY entry (#call iterates the whole hash), so it has no
-        # unconstrained tail: whatever `other` asks of any key, @value_type already
-        # guarantees. What a map does NOT promise is that any particular key is
-        # PRESENT, so a key `other` requires can never be satisfied.
+        # Maps constrain every value but do not guarantee any named key is present.
         return false if other.literal_fields.any? { |k, _| !k.optional? }
 
         return other._schema.all? { |_k, field| Plumb::Subtyping.subtype?(@value_type, field) }

--- a/lib/plumb/metadata.rb
+++ b/lib/plumb/metadata.rb
@@ -12,12 +12,10 @@ module Plumb
       freeze
     end
 
-    # Identified by the wrapped type as well as the merged metadata. Two types can
-    # carry identical metadata and still describe different values — a Constraint
-    # contributes none of its own, so `Integer[1..10]` and `Integer[100..200]`
-    # labelled alike would otherwise compare equal, and `==` is what
-    # Plumb::Subtyping.subtype? and the Optimizer consult before their
-    # #identity_wrapper? guard.
+    # Metadata nodes include their wrapped type in equality; otherwise unrelated
+    # types carrying the same metadata could collapse during subtype reductions.
+    # @param other [Object]
+    # @return [Boolean]
     def ==(other)
       other.instance_of?(self.class) && type == other.type && @metadata == other.metadata
     end

--- a/lib/plumb/metadata.rb
+++ b/lib/plumb/metadata.rb
@@ -12,8 +12,14 @@ module Plumb
       freeze
     end
 
+    # Identified by the wrapped type as well as the merged metadata. Two types can
+    # carry identical metadata and still describe different values — a Constraint
+    # contributes none of its own, so `Integer[1..10]` and `Integer[100..200]`
+    # labelled alike would otherwise compare equal, and `==` is what
+    # Plumb::Subtyping.subtype? and the Optimizer consult before their
+    # #identity_wrapper? guard.
     def ==(other)
-      other.is_a?(self.class) && @metadata == other.metadata
+      other.instance_of?(self.class) && type == other.type && @metadata == other.metadata
     end
 
     def metadata(data = Undefined)

--- a/lib/plumb/not.rb
+++ b/lib/plumb/not.rb
@@ -38,6 +38,24 @@ module Plumb
       self.class.new(step)
     end
 
+    # Negation is CONTRAVARIANT: `Not(A) <= Not(B)` exactly when `B <= A`.
+    #
+    # `Not(A)` accepts everything OUTSIDE A, so the wider the negated type, the
+    # narrower the negation. `Not[Numeric]` excludes every number and so is a
+    # subtype of `Not[Integer]`, which excludes only integers and still accepts
+    # `1.5`. The default covariant-container rule reads the children the other way
+    # round and gets both directions wrong.
+    def subtype_of?(other)
+      return true if self == other
+      return Plumb::Subtyping.subtype?(other.children.first, @step) if other.is_a?(Not)
+
+      super
+    end
+
+    # A negation checks the value and passes it through untouched — #call only
+    # flips validity.
+    def value_preserving? = true
+
     private def _inspect
       %(Not(#{@step.inspect}))
     end

--- a/lib/plumb/not.rb
+++ b/lib/plumb/not.rb
@@ -38,13 +38,10 @@ module Plumb
       self.class.new(step)
     end
 
-    # Negation is CONTRAVARIANT: `Not(A) <= Not(B)` exactly when `B <= A`.
-    #
-    # `Not(A)` accepts everything OUTSIDE A, so the wider the negated type, the
-    # narrower the negation. `Not[Numeric]` excludes every number and so is a
-    # subtype of `Not[Integer]`, which excludes only integers and still accepts
-    # `1.5`. The default covariant-container rule reads the children the other way
-    # round and gets both directions wrong.
+    # Negation is contravariant: Not(A) <= Not(B) when B <= A, because excluding
+    # a wider set produces a narrower complement.
+    # @param other [Composable]
+    # @return [Boolean]
     def subtype_of?(other)
       return true if self == other
       return Plumb::Subtyping.subtype?(other.children.first, @step) if other.is_a?(Not)
@@ -52,8 +49,7 @@ module Plumb
       super
     end
 
-    # A negation checks the value and passes it through untouched — #call only
-    # flips validity.
+    # @return [Boolean] true because negation only changes validity
     def value_preserving? = true
 
     private def _inspect

--- a/lib/plumb/optimizer.rb
+++ b/lib/plumb/optimizer.rb
@@ -153,7 +153,7 @@ module Plumb
         node = node.base
       end
       root = node
-      return nil unless root.is_a?(Constraint) && root.matcher.is_a?(::Module)
+      return nil unless root.is_a?(Constraint) && SemanticMatcher.nominal?(root.matcher)
       return nil unless Subtyping.subtype?(Subtyping.resolved_output(left), root)
 
       # Stack right's refinements onto left; Constraint.narrow intersects Ranges

--- a/lib/plumb/pipeline.rb
+++ b/lib/plumb/pipeline.rb
@@ -62,6 +62,17 @@ module Plumb
     def input_type = @type.input_type
     def output_type = @type.output_type
 
+    # Transparency extends to the subtype relation: a Pipeline IS its accumulated
+    # composition, so `subtype?` reduces to that inner type on either side (see
+    # Composable#subtype_identity). Without this a Pipeline would delegate its
+    # type-flow — so `#>>` type-checks against it — while relating to nothing,
+    # which also kept a pipeline-typed field out of container subtyping.
+    def subtype_identity = @type
+
+    # Likewise for the reductions: a Pipeline changes the value exactly when the
+    # composition it wraps does.
+    def value_preserving? = @type.value_preserving?
+
     # Add a step. A pipeline is a sequence of validators/coercions that
     # progressively narrows its data, so steps are **non-strict** by default:
     # `#step` chains with `#/`, skipping the composition type-check (a later step

--- a/lib/plumb/pipeline.rb
+++ b/lib/plumb/pipeline.rb
@@ -62,15 +62,13 @@ module Plumb
     def input_type = @type.input_type
     def output_type = @type.output_type
 
-    # Transparency extends to the subtype relation: a Pipeline IS its accumulated
-    # composition, so `subtype?` reduces to that inner type on either side (see
-    # Composable#subtype_identity). Without this a Pipeline would delegate its
-    # type-flow — so `#>>` type-checks against it — while relating to nothing,
-    # which also kept a pipeline-typed field out of container subtyping.
+    # Use the accumulated composition as this pipeline's subtype identity. Merely
+    # delegating input/output flow would let composition checks work while leaving
+    # the Pipeline unrelated to the same type inside containers.
+    # @return [Composable]
     def subtype_identity = @type
 
-    # Likewise for the reductions: a Pipeline changes the value exactly when the
-    # composition it wraps does.
+    # @return [Boolean] whether the accumulated composition preserves values
     def value_preserving? = @type.value_preserving?
 
     # Add a step. A pipeline is a sequence of validators/coercions that

--- a/lib/plumb/policy.rb
+++ b/lib/plumb/policy.rb
@@ -25,11 +25,10 @@ module Plumb
       freeze
     end
 
-    # A Policy is identified by its name, its argument AND the step it wraps. The
-    # step is load-bearing: `String.present` and `Integer.present` share a name and
-    # argument while accepting disjoint values, and `subtype?` short-circuits on
-    # `==` before the #identity_wrapper? guard that keeps a wrapper from being
-    # dropped — so without the step, `|` would absorb one into the other.
+    # Policy equality includes the wrapped step; otherwise same-named policies on
+    # disjoint types would compare equal and one could be reduced away.
+    # @param other [Object]
+    # @return [Boolean]
     def ==(other)
       other.instance_of?(self.class) &&
         policy_name == other.policy_name &&

--- a/lib/plumb/policy.rb
+++ b/lib/plumb/policy.rb
@@ -25,10 +25,16 @@ module Plumb
       freeze
     end
 
+    # A Policy is identified by its name, its argument AND the step it wraps. The
+    # step is load-bearing: `String.present` and `Integer.present` share a name and
+    # argument while accepting disjoint values, and `subtype?` short-circuits on
+    # `==` before the #identity_wrapper? guard that keeps a wrapper from being
+    # dropped — so without the step, `|` would absorb one into the other.
     def ==(other)
-      other.is_a?(self.class) &&
+      other.instance_of?(self.class) &&
         policy_name == other.policy_name &&
-        arg == other.arg
+        arg == other.arg &&
+        children == other.children
     end
 
     # A Policy is a transparent wrapper: it delegates type-flow to the wrapped

--- a/lib/plumb/relation.rb
+++ b/lib/plumb/relation.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+module Plumb
+  # Internal three-valued result for propositions the type algebra attempts to
+  # prove. Unknown is distinct from false so callers cannot turn missing
+  # knowledge into an unsafe rewrite.
+  class Relation
+    class << self
+      # Converts a known predicate result to a proof.
+      # @param value [Object]
+      # @return [Relation]
+      def from(value) = value ? PROVEN : DISPROVEN
+
+      # Combines proofs for a logical conjunction.
+      # @param relations [Enumerable<Relation>]
+      # @return [Relation]
+      def all(relations)
+        unknown = false
+        relations.each do |relation|
+          return DISPROVEN if relation.disproven?
+
+          unknown ||= relation.unknown?
+        end
+        unknown ? UNKNOWN : PROVEN
+      end
+
+      # Combines proofs for a logical disjunction.
+      # @param relations [Enumerable<Relation>]
+      # @return [Relation]
+      def any(relations)
+        unknown = false
+        relations.each do |relation|
+          return PROVEN if relation.proven?
+
+          unknown ||= relation.unknown?
+        end
+        unknown ? UNKNOWN : DISPROVEN
+      end
+
+      private :new
+    end
+
+    # @return [Boolean]
+    def proven? = equal?(PROVEN)
+
+    # @return [Boolean]
+    def disproven? = equal?(DISPROVEN)
+
+    # @return [Boolean]
+    def unknown? = equal?(UNKNOWN)
+
+    PROVEN = new.freeze
+    DISPROVEN = new.freeze
+    UNKNOWN = new.freeze
+  end
+  private_constant :Relation
+end

--- a/lib/plumb/semantic_matcher.rb
+++ b/lib/plumb/semantic_matcher.rb
@@ -1,0 +1,393 @@
+# frozen_string_literal: true
+
+require 'set'
+
+module Plumb
+  # Internal semantic form of Ruby `#===` matchers. Raw matchers are normalized
+  # once at a Constraint boundary; nodes then collaborate polymorphically.
+  module SemanticMatcher
+    class Merge
+      attr_reader :node
+
+      class << self
+        def merged(node) = new(:merged, node)
+
+        private :new
+      end
+
+      def initialize(state, node = nil)
+        @state = state
+        @node = node
+        freeze
+      end
+
+      def merged? = @state == :merged
+      def empty? = equal?(EMPTY)
+      def unknown? = equal?(UNKNOWN)
+
+      EMPTY = new(:empty)
+      UNKNOWN = new(:unknown)
+    end
+
+    class Node
+      attr_reader :raw
+
+      def initialize(raw)
+        @raw = raw
+        freeze
+      end
+
+      def kind = :opaque
+      def singleton? = false
+      def nominal? = false
+      def matcher_domain = []
+      def value_domain = raw.class
+      def error_message = "Must match #{raw.inspect}"
+      def matches_value(_candidate) = Relation::UNKNOWN
+
+      def equivalent?(other)
+        other.instance_of?(self.class) && raw == other.raw
+      end
+
+      def subset_of(other)
+        return Relation::PROVEN if equivalent?(other)
+
+        other.subset_from_opaque(self)
+      end
+
+      def subset_from_opaque(_other) = Relation::UNKNOWN
+      def subset_from_nominal(_other) = Relation::UNKNOWN
+      def subset_from_literal(_other) = Relation::UNKNOWN
+      def subset_from_text_literal(other) = subset_from_literal(other)
+      def subset_from_numeric_literal(other) = subset_from_literal(other)
+      def subset_from_finite_set(_other) = Relation::UNKNOWN
+      def subset_from_range(_other) = Relation::UNKNOWN
+      def subset_from_pattern(_other) = Relation::UNKNOWN
+
+      def overlap(other)
+        return Relation::PROVEN if equivalent?(other)
+
+        other.overlap_with_opaque(self)
+      end
+
+      def overlap_with_opaque(_other) = Relation::UNKNOWN
+      def overlap_with_nominal(_other) = Relation::UNKNOWN
+      def overlap_with_literal(_other) = Relation::UNKNOWN
+      def overlap_with_text_literal(other) = overlap_with_literal(other)
+      def overlap_with_numeric_literal(other) = overlap_with_literal(other)
+      def overlap_with_finite_set(_other) = Relation::UNKNOWN
+      def overlap_with_range(_other) = Relation::UNKNOWN
+      def overlap_with_pattern(_other) = Relation::UNKNOWN
+
+      def intersect(_other) = Merge::UNKNOWN
+      def intersect_with_finite_set(_other) = Merge::UNKNOWN
+      def intersect_with_range(_other) = Merge::UNKNOWN
+    end
+
+    class Opaque < Node
+    end
+
+    class CollectionMatcher < Opaque
+      def kind = :collection_matcher
+      def error_message = "Must be equal to #{raw}"
+    end
+
+    class Literal < Node
+      def kind = :literal
+      def singleton? = true
+      def matcher_domain = [value_domain]
+      def matches_value(candidate) = Relation.from(raw === candidate)
+      def error_message = "Must be equal to #{raw}"
+
+      def subset_of(other)
+        return Relation::PROVEN if equivalent?(other)
+
+        other.subset_from_literal(self)
+      end
+
+      def subset_from_literal(_other) = Relation::DISPROVEN
+
+      def overlap(other)
+        return Relation::PROVEN if equivalent?(other)
+
+        other.overlap_with_literal(self)
+      end
+
+      def overlap_with_literal(_other) = Relation::DISPROVEN
+      def overlap_with_nominal(other) = other.overlap_with_literal(self)
+      def overlap_with_range(other) = other.overlap_with_literal(self)
+      def overlap_with_pattern(other) = other.overlap_with_literal(self)
+    end
+
+    class TextLiteral < Literal
+      def kind = :text_literal
+
+      def subset_of(other)
+        return Relation::PROVEN if equivalent?(other)
+
+        other.subset_from_text_literal(self)
+      end
+
+      def overlap(other)
+        return Relation::PROVEN if equivalent?(other)
+
+        other.overlap_with_text_literal(self)
+      end
+    end
+
+    class NumericLiteral < Literal
+      def kind = :numeric_literal
+      def value_domain = ::Numeric
+
+      def subset_of(other)
+        return Relation::PROVEN if equivalent?(other)
+
+        other.subset_from_numeric_literal(self)
+      end
+
+      def overlap(other)
+        return Relation::PROVEN if equivalent?(other)
+
+        other.overlap_with_numeric_literal(self)
+      end
+    end
+
+    class Nominal < Node
+      def kind = :nominal
+      def nominal? = true
+      def matcher_domain = raw.is_a?(::Class) ? [raw] : []
+      def matches_value(candidate) = Relation.from(raw === candidate)
+
+      def error_message
+        raw.is_a?(::Class) ? "Must be a #{raw}" : super
+      end
+
+      def subset_of(other)
+        return Relation::PROVEN if equivalent?(other)
+
+        other.subset_from_nominal(self)
+      end
+
+      def subset_from_nominal(other) = Relation.from((other.raw <= raw) == true)
+      def subset_from_literal(other) = matches_value(other.raw)
+      def subset_from_numeric_literal(_other) = SemanticMatcher.wrap(::Numeric).subset_of(self)
+      def subset_from_finite_set(other) = other.members_match(self)
+      def subset_from_range(other) = other.endpoints_within(self)
+
+      def subset_from_pattern(other)
+        Relation.all(other.matcher_domain.map { |domain| SemanticMatcher.wrap(domain).subset_of(self) })
+      end
+
+      def overlap(other)
+        return Relation::PROVEN if equivalent?(other)
+
+        other.overlap_with_nominal(self)
+      end
+
+      def overlap_with_nominal(other)
+        return Relation::PROVEN if subset_from_nominal(other).proven? || other.subset_from_nominal(self).proven?
+        return Relation::DISPROVEN if raw.is_a?(::Class) && other.raw.is_a?(::Class)
+
+        Relation::UNKNOWN # unrelated mixins may share an implementing class
+      end
+
+      def overlap_with_literal(other) = Relation.from(other.raw.is_a?(raw))
+      def overlap_with_range(other) = other.overlap_with_nominal(self)
+      def overlap_with_pattern(other) = other.overlap_with_nominal(self)
+    end
+
+    class FiniteSet < Node
+      def kind = :finite_set
+      def matcher_domain = raw.map(&:class).uniq
+      def matches_value(candidate) = Relation.from(raw === candidate)
+
+      def subset_of(other)
+        return Relation::PROVEN if equivalent?(other)
+
+        other.subset_from_finite_set(self)
+      end
+
+      def subset_from_literal(other) = matches_value(other.raw)
+      def subset_from_numeric_literal(_other) = Relation::DISPROVEN
+      def subset_from_finite_set(other) = Relation.from(other.raw.subset?(raw))
+
+      def members_match(other)
+        Relation.all(raw.map { |member| other.matches_value(member) })
+      end
+
+      def overlap(other)
+        return Relation::PROVEN if equivalent?(other)
+
+        other.overlap_with_finite_set(self)
+      end
+
+      def overlap_with_finite_set(other)
+        Relation.from(!(raw & other.raw).empty?)
+      end
+
+      def intersect(other) = other.intersect_with_finite_set(self)
+
+      def intersect_with_finite_set(other)
+        merged = raw & other.raw
+        merged.empty? ? Merge::EMPTY : Merge.merged(self.class.new(merged))
+      end
+    end
+
+    class Interval < Node
+      def kind = :range
+
+      def matcher_domain
+        endpoint = raw.begin || raw.end
+        endpoint.nil? ? [] : [SemanticMatcher.value_domain(endpoint)]
+      end
+
+      def matches_value(candidate) = Relation.from(raw === candidate)
+      def error_message = "Must be within #{raw}"
+
+      def subset_of(other)
+        return Relation::PROVEN if equivalent?(other)
+
+        other.subset_from_range(self)
+      end
+
+      def subset_from_literal(other) = matches_value(other.raw)
+      def subset_from_finite_set(other) = other.members_match(self)
+
+      def subset_from_range(other)
+        lo = if raw.begin.nil?
+               Relation::PROVEN
+             elsif other.raw.begin.nil?
+               Relation::DISPROVEN
+             else
+               Relation.from(raw.cover?(other.raw.begin))
+             end
+        Relation.all([lo, other.end_within(self)])
+      rescue ::ArgumentError, ::TypeError
+        Relation::UNKNOWN
+      end
+
+      def endpoints_within(nominal)
+        endpoints = [raw.begin, raw.end].compact
+        return Relation::UNKNOWN if endpoints.empty?
+
+        Relation.all(endpoints.map { |endpoint| nominal.matches_value(endpoint) })
+      end
+
+      def end_within(outer)
+        return Relation::PROVEN if outer.raw.end.nil?
+        return Relation::DISPROVEN if raw.end.nil?
+
+        cmp = raw.end <=> outer.raw.end
+        return Relation::UNKNOWN if cmp.nil?
+
+        Relation.from(!raw.exclude_end? && outer.raw.exclude_end? ? cmp.negative? : cmp <= 0)
+      end
+
+      def overlap(other)
+        return Relation::PROVEN if equivalent?(other)
+
+        other.overlap_with_range(self)
+      end
+
+      def overlap_with_nominal(other)
+        endpoint = raw.begin || raw.end
+        endpoint.nil? ? Relation::UNKNOWN : other.matches_value(endpoint)
+      end
+
+      def overlap_with_literal(other) = matches_value(other.raw)
+
+      def overlap_with_range(other)
+        merged = intersect_with_range(other)
+        return Relation::DISPROVEN if merged.empty?
+        return Relation::PROVEN if merged.merged?
+
+        Relation::UNKNOWN
+      end
+
+      def intersect(other) = other.intersect_with_range(self)
+
+      def intersect_with_range(other)
+        ab = raw.begin
+        bb = other.raw.begin
+        new_begin = ab.nil? ? bb : (bb.nil? ? ab : (ab >= bb ? ab : bb))
+        ae = raw.end
+        be = other.raw.end
+        new_end, new_exclude =
+          if ae.nil? then [be, other.raw.exclude_end?]
+          elsif be.nil? then [ae, raw.exclude_end?]
+          elsif ae < be then [ae, raw.exclude_end?]
+          elsif be < ae then [be, other.raw.exclude_end?]
+          else [ae, raw.exclude_end? || other.raw.exclude_end?]
+          end
+        unless new_begin.nil? || new_end.nil?
+          return Merge::EMPTY if new_begin > new_end
+          return Merge::EMPTY if new_begin == new_end && new_exclude
+        end
+        Merge.merged(self.class.new(::Range.new(new_begin, new_end, new_exclude)))
+      rescue ::ArgumentError, ::TypeError
+        Merge::UNKNOWN
+      end
+    end
+
+    class Pattern < Node
+      def kind = :pattern
+      def matcher_domain = [::String, ::Symbol]
+      def matches_value(candidate) = Relation.from(raw === candidate)
+
+      def subset_of(other)
+        return Relation::PROVEN if equivalent?(other)
+
+        other.subset_from_pattern(self)
+      end
+
+      def subset_from_text_literal(other) = matches_value(other.raw.to_s)
+
+      def overlap(other)
+        return Relation::PROVEN if equivalent?(other)
+
+        other.overlap_with_pattern(self)
+      end
+
+      def overlap_with_nominal(other)
+        Relation.any(matcher_domain.map { |domain| SemanticMatcher.wrap(domain).overlap(other) })
+      end
+
+      def overlap_with_literal(other)
+        return Relation::UNKNOWN unless other.is_a?(TextLiteral)
+
+        matches_value(other.raw.to_s)
+      end
+    end
+
+    module_function
+
+    # The only raw-class normalization switch. Core algebra receives nodes.
+    def wrap(raw)
+      return raw if raw.is_a?(Node)
+
+      case raw
+      when ::Module then Nominal.new(raw)
+      when ::Range then Interval.new(raw)
+      when ::Set then FiniteSet.new(raw)
+      when ::Regexp then Pattern.new(raw)
+      when ::Numeric then NumericLiteral.new(raw)
+      when ::String, ::Symbol then TextLiteral.new(raw)
+      when ::TrueClass, ::FalseClass, ::NilClass then Literal.new(raw)
+      when ::Array, ::Hash then CollectionMatcher.new(raw)
+      else Opaque.new(raw)
+      end
+    end
+
+    def value_domain(raw) = wrap(raw).value_domain
+    def matcher_domain(raw) = wrap(raw).matcher_domain
+    def singleton?(raw) = wrap(raw).singleton?
+    def nominal?(raw) = wrap(raw).nominal?
+    def error_message(raw) = wrap(raw).error_message
+
+    def merge(left, right)
+      wrap(left).intersect(wrap(right))
+    end
+
+  end
+  private_constant :SemanticMatcher
+end

--- a/lib/plumb/static_class.rb
+++ b/lib/plumb/static_class.rb
@@ -28,6 +28,23 @@ module Plumb
     # at composition time, eg. `Types::Static['foo'] >> Types::Integer` raises.
     def input_type = Types::Any
 
+    # A static step is identified by the value it PRODUCES, so it is a subtype of
+    # any type that value satisfies — which is what lets `Types::Integer.static(10)`
+    # (ie. `Static[10] >> Types::Integer`) compose, while `Static['foo'] >>
+    # Types::Integer` raises.
+    #
+    # Asked of the value itself rather than through Subtyping.atomic_subtype?,
+    # because a literal MATCHER and a produced value are different things and each
+    # reading is right for its own node. `Types::Value[5]` matches by `==` and so
+    # describes every numeric spelling of 5 (hence Numeric, not Integer); the value
+    # here is one concrete object, and `Static[10]` really does produce an Integer.
+    def subtype_of?(other)
+      return true if self == other
+      return super if @value.is_a?(Composable)
+
+      other === @value
+    end
+
     def call(result)
       result.valid!(@value)
     end

--- a/lib/plumb/static_class.rb
+++ b/lib/plumb/static_class.rb
@@ -28,16 +28,10 @@ module Plumb
     # at composition time, eg. `Types::Static['foo'] >> Types::Integer` raises.
     def input_type = Types::Any
 
-    # A static step is identified by the value it PRODUCES, so it is a subtype of
-    # any type that value satisfies — which is what lets `Types::Integer.static(10)`
-    # (ie. `Static[10] >> Types::Integer`) compose, while `Static['foo'] >>
-    # Types::Integer` raises.
-    #
-    # Asked of the value itself rather than through Subtyping.atomic_subtype?,
-    # because a literal MATCHER and a produced value are different things and each
-    # reading is right for its own node. `Types::Value[5]` matches by `==` and so
-    # describes every numeric spelling of 5 (hence Numeric, not Integer); the value
-    # here is one concrete object, and `Static[10]` really does produce an Integer.
+    # Tests the concrete produced value directly. Atomic matcher logic is unsuitable
+    # here because it models matched values and widens numeric equality domains.
+    # @param other [Composable]
+    # @return [Boolean]
     def subtype_of?(other)
       return true if self == other
       return super if @value.is_a?(Composable)

--- a/lib/plumb/subtyping.rb
+++ b/lib/plumb/subtyping.rb
@@ -274,6 +274,14 @@ module Plumb
       accepted = accepted_type(right)
       return if accepted.is_a?(AnyClass) || subtype?(produced, accepted)
 
+      # Retry reading a produced record as CLOSED. A Hash schema describes incoming
+      # hashes, which may carry keys it ignores — so it is deliberately NOT a subtype
+      # of a consumer that constrains those keys. What it EMITS is narrower: #call
+      # copies over only the keys it declares. So `Hash[name: String] >>
+      # Hash[name: String, age?: Integer]` composes (no `age` can reach the
+      # consumer) while the schema-level relation stays strict. @see HashClass#closed
+      return if produced.is_a?(HashClass) && subtype?(produced.closed, accepted)
+
       raise Plumb::TypeError,
             "cannot compose #{left.inspect} >> #{right.inspect}: " \
             "#{produced.inspect} (produced) is not a subtype of #{accepted.inspect} (accepted); " \
@@ -336,8 +344,8 @@ module Plumb
       end
 
       # Distribute over unions: (a1 | a2) & b == (a1 & b) | (a2 & b).
-      return intersect_union(a, b) if a.is_a?(Disjunction)
-      return intersect_union(b, a) if b.is_a?(Disjunction)
+      return intersect_union(a, b, union_first: true) if a.is_a?(Disjunction)
+      return intersect_union(b, a, union_first: false) if b.is_a?(Disjunction)
 
       intersect_constraints(a, b) ||
         intersect_literals(a, b) ||
@@ -348,9 +356,15 @@ module Plumb
     # Distribute `&` over a union: intersect each branch with `other`, drop the
     # branches that go Never, and rejoin the survivors with `|`. All-Never ⇒
     # Never. A branch the reducer can't fold becomes a runtime And.
-    def intersect_union(union, other)
+    # `union_first` records which side the union came from, so each branch is
+    # recombined in the ORIGINAL order. It matters whenever a branch cannot be
+    # folded: the fallback is Conjunction.build, which for a converting operand is a
+    # SEQUENTIAL And, and `And(Static[5], String)` is not `And(String, Static[5])` —
+    # the first emits 5 and then checks it, the second checks the input first.
+    def intersect_union(union, other, union_first: true)
       parts = union.children.filter_map do |branch|
-        m = intersect(branch, other) || Conjunction.build(branch, other)
+        left, right = union_first ? [branch, other] : [other, branch]
+        m = intersect(left, right) || Conjunction.build(left, right)
         m unless m.is_a?(NeverClass)
       end
       return Types::Never if parts.empty?
@@ -494,7 +508,16 @@ module Plumb
     # converting side — Conjunction.build keeps both — while a wrong Never discards
     # the whole composition.
     def stable_domain(type)
-      accepted = Plumb.resolve_base_types(accepted_type(type))
+      consumes = accepted_type(type)
+      # A converting node that cannot describe its input falls back to reporting
+      # ITSELF as what it accepts, which then resolves to what it PRODUCES — so the
+      # two look identical while genuinely differing. A Types::Data class is the
+      # case in point: it takes a Hash and returns an instance, but answers `self`
+      # on both sides, which would make it look disjoint from Types::Hash and sink
+      # `Types::Hash & Person` to Never. Unknown, so decline.
+      return nil if consumes.equal?(type) && !value_preserving?(type)
+
+      accepted = Plumb.resolve_base_types(consumes)
       return nil if accepted.empty?
 
       accepted == Plumb.resolve_base_types(resolved_output(type)) ? accepted : nil

--- a/lib/plumb/subtyping.rb
+++ b/lib/plumb/subtyping.rb
@@ -123,13 +123,21 @@ module Plumb
     # `a` and `b` describe the same values — mutual subtypes.
     def equivalent?(a, b) = subtype?(a, b) && subtype?(b, a)
 
-    # A leaf type whose single child is a raw (non-Composable) Ruby matcher or
-    # value — eg. Constraint, ValueClass, StaticClass. These bottom out in
-    # #atomic_subtype? rather than recursing.
+    # A leaf type whose single child is a raw (non-Composable) Ruby MATCHER — eg.
+    # Constraint, ValueClass. These bottom out in #atomic_subtype? rather than
+    # recursing.
+    #
+    # A StaticClass looks the same shape but is excluded: its child is the value it
+    # PRODUCES, not a matcher it compares against (it accepts any input), so
+    # comparing the two children as matchers relates the wrong things —
+    # `Types::Value[5] <= Types::Static[5]` would hold, and via `Static[5] <=
+    # Types::Integer` that breaks transitivity. Static answers for itself instead
+    # (see StaticClass#subtype_of?).
     def atomic?(type)
       type.respond_to?(:children) &&
         type.children.size == 1 &&
-        !type.children.first.is_a?(Composable)
+        !type.children.first.is_a?(Composable) &&
+        !type.is_a?(StaticClass)
     end
 
     # The subtype relation between two raw matchers (a Class/Module, Range,
@@ -144,9 +152,17 @@ module Plumb
         case lm
         when ::Module then class_le?(lm, rm)        # Integer <= Numeric
         when ::Range then range_in_class?(lm, rm)   # (1..10) <= Integer
-        when ::Regexp then class_le?(::String, rm)  # /x/ matches Strings
+        # `Regexp#===` coerces, so a pattern matches Symbols as well as Strings
+        # (`/x/ === :xyz`). It is a subtype of a class only if BOTH are.
+        when ::Regexp then class_le?(::String, rm) && class_le?(::Symbol, rm)
         when ::Set then lm.all? { |e| rm === e }    # Set[1,2,3] <= Integer
-        else rm === lm                              # value 5 <= Integer
+        # A literal matches by Ruby's `==`, which for numerics crosses their
+        # classes — `Types::Value[5]` accepts `5`, `5.0`, `5r` and `BigDecimal('5')`
+        # alike. So a numeric literal describes Numeric, and is confined to Integer
+        # only if Numeric itself is. (A Static is different: it PRODUCES one
+        # concrete object rather than matching a set — see StaticClass#subtype_of?.)
+        when ::Numeric then class_le?(::Numeric, rm)
+        else rm === lm                              # value 'a' <= String
         end
       when ::Range
         case lm
@@ -159,6 +175,10 @@ module Plumb
         case lm
         when ::Set then lm.subset?(rm)              # Set[2,3] <= Set[1,2,3,4]
         when ::Module, ::Range, ::Regexp then false # infinite domain ⊄ finite set
+        # `Set#===` is `#include?`, which tests `eql?` — so a Set holds ONE numeric
+        # spelling, not every value `== lm`. `Types::Value[5]` accepts `5.0`, which
+        # `Set[1, 5]` rejects.
+        when ::Numeric then false
         else rm === lm                              # value is a member
         end
       when ::Regexp
@@ -177,19 +197,57 @@ module Plumb
       (a <= b) == true
     end
 
+    # Is every value a Range matches an instance of `klass`?
+    #
+    # BOTH endpoints have to be instances: reading only one accepts
+    # `(1..2.5) <= Integer` and `(1.5..3) <= Float`, though the other endpoint
+    # matches values of a different class.
+    #
+    # Note this reads a numeric range as describing its endpoints' class, matching
+    # how a numeric LITERAL is read (see #atomic_subtype?) — `(1..10) === 2.5` is
+    # true, so both are the same open question about numeric `==` crossing classes.
     def range_in_class?(range, klass)
-      e = range.begin || range.end
-      !e.nil? && e.is_a?(klass)
+      ends = [range.begin, range.end].compact
+      return false if ends.empty?
+
+      ends.all? { |e| e.is_a?(klass) }
     end
 
+    # Is `inner` contained in `outer`? Endpoint containment, honouring
+    # `#exclude_end?` on BOTH sides — `cover?` alone would reject `(1...5)` inside
+    # `(0...5)` for an endpoint (`5`) that `inner` does not actually include.
+    # Ruby has no exclusive BEGIN, so the low end stays a plain `cover?`.
+    #
+    # Conservative where containment needs discreteness: `(1...5) <= (0..4)` stays
+    # false, since `4.5` separates them for a non-integer base.
     def range_in_range?(inner, outer)
       lo_ok = outer.begin.nil? || (!inner.begin.nil? && outer.cover?(inner.begin))
-      hi_ok = outer.end.nil? || (!inner.end.nil? && outer.cover?(inner.end))
-      lo_ok && hi_ok
+      lo_ok && range_end_within?(inner, outer)
     end
 
+    def range_end_within?(inner, outer)
+      return true if outer.end.nil?
+      return false if inner.end.nil?
+
+      cmp = inner.end <=> outer.end
+      return false if cmp.nil? # incomparable endpoints prove nothing
+
+      # `inner` reaches its end while `outer` stops short of the same value, so
+      # inner's end must fall strictly inside. Every other combination — both
+      # exclusive, both inclusive, or inner exclusive inside an inclusive outer —
+      # is satisfied by `<=`.
+      if !inner.exclude_end? && outer.exclude_end?
+        cmp.negative?
+      else
+        cmp <= 0
+      end
+    end
+
+    # Regexps are equal when they match the same strings. `#source` alone is not
+    # that: `i`, `m` and `x` change what a pattern accepts (`/a/i` matches `'A'`,
+    # `/a/` does not), and `#options` is where they live.
     def regex_equal?(a, b)
-      a.is_a?(::Regexp) && b.is_a?(::Regexp) && a.source == b.source
+      a.is_a?(::Regexp) && b.is_a?(::Regexp) && a.source == b.source && a.options == b.options
     end
 
     # Validate that two steps can be composed sequentially (`left >> right`).
@@ -400,11 +458,46 @@ module Plumb
     # (opaque matcher ⇒ empty base-type list) is NOT provably disjoint, so the
     # caller keeps a runtime And rather than wrongly collapsing to Never.
     def disjoint_atomic?(a, b)
-      abt = Plumb.resolve_base_types(a)
-      bbt = Plumb.resolve_base_types(b)
-      return false if abt.empty? || bbt.empty?
+      # Only judge two nodes that both return their input unchanged.
+      #
+      # "No value satisfies both" is the right question for a genuine meet, where
+      # each side describes the SAME value. It is the wrong question everywhere
+      # else, and Plumb.resolve_base_types answers about what a node PRODUCES: a
+      # Function reports its output type, a Static the class of the fixed value it
+      # returns whatever its input, a Not the very classes it excludes. Judging
+      # those sinks an inhabited intersection to Never — `Types::Integer &
+      # Types::Integer.transform(::String, &:to_s)` accepts every Integer, and
+      # `Types::String & Types::Not[Types::Integer]` accepts every String.
+      #
+      abt = stable_domain(a)
+      bbt = stable_domain(b)
+      return false if abt.nil? || bbt.nil?
 
       abt.none? { |x| bbt.any? { |y| class_le?(x, y) || class_le?(y, x) } }
+    end
+
+    # The Ruby classes `type` accepts, but ONLY when they are also the classes it
+    # produces — ie. the node NARROWS one domain rather than moving between two.
+    # nil for anything else, including an unknown domain.
+    #
+    # That distinction is what makes #disjoint_atomic? answerable. "No value
+    # satisfies both" is a question about a single domain, so it can only be asked
+    # of a node that has one. A converting node has two, and Plumb.resolve_base_types
+    # reports only the produced side — which is how `Types::Integer &
+    # Types::Integer.transform(::String, &:to_s)` came to look disjoint (Integer vs
+    # String) though its And accepts every Integer. A Static reports the class of
+    # the value it emits regardless of input, and a Not reports the very classes it
+    # excludes; neither has a domain to compare either.
+    #
+    # Declining here costs only precision: the caller keeps a runtime intersection
+    # where it might have proved Never. That matches what `&` already does for a
+    # converting side — Conjunction.build keeps both — while a wrong Never discards
+    # the whole composition.
+    def stable_domain(type)
+      accepted = Plumb.resolve_base_types(accepted_type(type))
+      return nil if accepted.empty?
+
+      accepted == Plumb.resolve_base_types(resolved_output(type)) ? accepted : nil
     end
 
     # Does `type` return its input unchanged on success (a coreflexive

--- a/lib/plumb/subtyping.rb
+++ b/lib/plumb/subtyping.rb
@@ -134,94 +134,10 @@ module Plumb
         !type.is_a?(StaticClass)
     end
 
-    # The subtype relation between two raw matchers (a Class/Module, Range,
-    # Regexp, or literal value). `atomic_subtype?(lm, rm)` is "does `lm` describe
-    # a subset of what `rm` describes?".
-    def atomic_subtype?(lm, rm)
-      return true if lm == rm
-      return regex_equal?(lm, rm) if lm.is_a?(::Regexp) && rm.is_a?(::Regexp)
-
-      case rm
-      when ::Module
-        case lm
-        when ::Module then class_le?(lm, rm)        # Integer <= Numeric
-        when ::Range then range_in_class?(lm, rm)   # (1..10) <= Integer
-        # Regexp#=== coerces Strings and Symbols, so both must fit.
-        when ::Regexp then class_le?(::String, rm) && class_le?(::Symbol, rm)
-        when ::Set then lm.all? { |e| rm === e }    # Set[1,2,3] <= Integer
-        # Numeric equality crosses concrete classes, so literals describe Numeric.
-        when ::Numeric then class_le?(::Numeric, rm)
-        else rm === lm                              # value 'a' <= String
-        end
-      when ::Range
-        case lm
-        when ::Range then range_in_range?(lm, rm)   # (1..10) <= (0..20)
-        when ::Set then lm.all? { |e| rm === e }    # Set[1,2,3] <= (0..10)
-        when ::Module, ::Regexp then false
-        else rm === lm                              # value within range
-        end
-      when ::Set
-        case lm
-        when ::Set then lm.subset?(rm)              # Set[2,3] <= Set[1,2,3,4]
-        when ::Module, ::Range, ::Regexp then false # infinite domain ⊄ finite set
-        # Set membership uses eql?, unlike numeric literal matching by ==.
-        when ::Numeric then false
-        else rm === lm                              # value is a member
-        end
-      when ::Regexp
-        case lm
-        when ::String, ::Symbol then rm === lm.to_s # literal string matches regex
-        else false
-        end
-      else
-        lm == rm                                    # literal value equality
-      end
-    end
-
-    def class_le?(a, b)
-      return false unless a.is_a?(::Module) && b.is_a?(::Module)
-
-      (a <= b) == true
-    end
-
-    # Tests whether both finite endpoints are instances of klass.
-    # @param range [Range]
-    # @param klass [Module]
-    # @return [Boolean]
-    def range_in_class?(range, klass)
-      ends = [range.begin, range.end].compact
-      return false if ends.empty?
-
-      ends.all? { |e| e.is_a?(klass) }
-    end
-
-    # Tests endpoint containment while respecting exclusive ends.
-    # @param inner [Range]
-    # @param outer [Range]
-    # @return [Boolean]
-    def range_in_range?(inner, outer)
-      lo_ok = outer.begin.nil? || (!inner.begin.nil? && outer.cover?(inner.begin))
-      lo_ok && range_end_within?(inner, outer)
-    end
-
-    def range_end_within?(inner, outer)
-      return true if outer.end.nil?
-      return false if inner.end.nil?
-
-      cmp = inner.end <=> outer.end
-      return false if cmp.nil? # incomparable endpoints prove nothing
-
-      # An inclusive inner end must fall strictly below an exclusive outer end.
-      if !inner.exclude_end? && outer.exclude_end?
-        cmp.negative?
-      else
-        cmp <= 0
-      end
-    end
-
-    # Compares Regexp source and semantic options.
-    def regex_equal?(a, b)
-      a.is_a?(::Regexp) && b.is_a?(::Regexp) && a.source == b.source && a.options == b.options
+    # The public Boolean form of the matcher subtype relation. Unknown relations
+    # conservatively return false: they must not justify removing a runtime check.
+    def atomic_subtype?(left_matcher, right_matcher)
+      SemanticMatcher.wrap(left_matcher).subset_of(SemanticMatcher.wrap(right_matcher)).proven?
     end
 
     # Validate that two steps can be composed sequentially (`left >> right`).
@@ -319,7 +235,7 @@ module Plumb
       intersect_constraints(a, b) ||
         intersect_literals(a, b) ||
         intersect_containers(a, b) ||
-        (disjoint_atomic?(a, b) ? Types::Never : nil)
+        (disjoint_relation(a, b).proven? ? Types::Never : nil)
     end
 
     # Distributes intersection over a union, preserving operand order for runtime
@@ -367,7 +283,7 @@ module Plumb
     # NOT disjoint, because `5 == 5.0`. That is also why literals can't be told
     # apart by base type — declaring `Value[5]`'s base to be Integer would make
     # it disjoint from Float and wrongly sink `Value[5] & Types::Float` — and so
-    # why this reasons over values instead of routing through #disjoint_atomic?.
+    # why this reasons over values instead of nominal-domain disjointness.
     #
     # Runs after #intersect_constraints, so two literals over the same base reach
     # here only once Constraint.merge_matchers has declined them (it merges
@@ -377,7 +293,7 @@ module Plumb
       bv = literal_value(b)
       return nil if Undefined.equal?(av) || Undefined.equal?(bv)
 
-      av == bv ? nil : Types::Never
+      Relation.from(av == bv).disproven? ? Types::Never : nil
     end
 
     # The single value a node matches by equality, or `Undefined` for a node that
@@ -434,17 +350,24 @@ module Plumb
     # @return [Composable] `type` itself, or a rebuilt container
     def map_children(type, &blk) = NodeMapper.map_children(type, &blk)
 
-    # Tests whether two stable, known domains have no related base classes.
-    # @param a [Composable]
-    # @param b [Composable]
-    # @return [Boolean]
-    def disjoint_atomic?(a, b)
+    # Attempts to prove that two stable nominal domains are disjoint. Unknown
+    # domains preserve the runtime intersection.
+    # @return [Relation]
+    def disjoint_relation(a, b)
       abt = stable_domain(a)
       bbt = stable_domain(b)
-      return false if abt.nil? || bbt.nil?
+      return Relation::UNKNOWN if abt.nil? || bbt.nil?
 
-      abt.none? { |x| bbt.any? { |y| class_le?(x, y) || class_le?(y, x) } }
+      overlaps = abt.product(bbt).map do |left_domain, right_domain|
+        SemanticMatcher.wrap(left_domain).overlap(SemanticMatcher.wrap(right_domain))
+      end
+      overlap = Relation.any(overlaps)
+      return Relation::DISPROVEN if overlap.proven?
+      return Relation::PROVEN if overlap.disproven?
+
+      Relation::UNKNOWN
     end
+    private_class_method :disjoint_relation
 
     # Returns the shared accepted/output base classes for a non-converting type.
     # Unknown or converting domains return nil; comparing their output classes as

--- a/lib/plumb/subtyping.rb
+++ b/lib/plumb/subtyping.rb
@@ -123,16 +123,10 @@ module Plumb
     # `a` and `b` describe the same values — mutual subtypes.
     def equivalent?(a, b) = subtype?(a, b) && subtype?(b, a)
 
-    # A leaf type whose single child is a raw (non-Composable) Ruby MATCHER — eg.
-    # Constraint, ValueClass. These bottom out in #atomic_subtype? rather than
-    # recursing.
-    #
-    # A StaticClass looks the same shape but is excluded: its child is the value it
-    # PRODUCES, not a matcher it compares against (it accepts any input), so
-    # comparing the two children as matchers relates the wrong things —
-    # `Types::Value[5] <= Types::Static[5]` would hold, and via `Static[5] <=
-    # Types::Integer` that breaks transitivity. Static answers for itself instead
-    # (see StaticClass#subtype_of?).
+    # Returns whether a node wraps one raw matcher. StaticClass is excluded because
+    # its child is an emitted value, not a matcher.
+    # @param type [Object]
+    # @return [Boolean]
     def atomic?(type)
       type.respond_to?(:children) &&
         type.children.size == 1 &&
@@ -152,15 +146,10 @@ module Plumb
         case lm
         when ::Module then class_le?(lm, rm)        # Integer <= Numeric
         when ::Range then range_in_class?(lm, rm)   # (1..10) <= Integer
-        # `Regexp#===` coerces, so a pattern matches Symbols as well as Strings
-        # (`/x/ === :xyz`). It is a subtype of a class only if BOTH are.
+        # Regexp#=== coerces Strings and Symbols, so both must fit.
         when ::Regexp then class_le?(::String, rm) && class_le?(::Symbol, rm)
         when ::Set then lm.all? { |e| rm === e }    # Set[1,2,3] <= Integer
-        # A literal matches by Ruby's `==`, which for numerics crosses their
-        # classes — `Types::Value[5]` accepts `5`, `5.0`, `5r` and `BigDecimal('5')`
-        # alike. So a numeric literal describes Numeric, and is confined to Integer
-        # only if Numeric itself is. (A Static is different: it PRODUCES one
-        # concrete object rather than matching a set — see StaticClass#subtype_of?.)
+        # Numeric equality crosses concrete classes, so literals describe Numeric.
         when ::Numeric then class_le?(::Numeric, rm)
         else rm === lm                              # value 'a' <= String
         end
@@ -175,9 +164,7 @@ module Plumb
         case lm
         when ::Set then lm.subset?(rm)              # Set[2,3] <= Set[1,2,3,4]
         when ::Module, ::Range, ::Regexp then false # infinite domain ⊄ finite set
-        # `Set#===` is `#include?`, which tests `eql?` — so a Set holds ONE numeric
-        # spelling, not every value `== lm`. `Types::Value[5]` accepts `5.0`, which
-        # `Set[1, 5]` rejects.
+        # Set membership uses eql?, unlike numeric literal matching by ==.
         when ::Numeric then false
         else rm === lm                              # value is a member
         end
@@ -197,15 +184,10 @@ module Plumb
       (a <= b) == true
     end
 
-    # Is every value a Range matches an instance of `klass`?
-    #
-    # BOTH endpoints have to be instances: reading only one accepts
-    # `(1..2.5) <= Integer` and `(1.5..3) <= Float`, though the other endpoint
-    # matches values of a different class.
-    #
-    # Note this reads a numeric range as describing its endpoints' class, matching
-    # how a numeric LITERAL is read (see #atomic_subtype?) — `(1..10) === 2.5` is
-    # true, so both are the same open question about numeric `==` crossing classes.
+    # Tests whether both finite endpoints are instances of klass.
+    # @param range [Range]
+    # @param klass [Module]
+    # @return [Boolean]
     def range_in_class?(range, klass)
       ends = [range.begin, range.end].compact
       return false if ends.empty?
@@ -213,13 +195,10 @@ module Plumb
       ends.all? { |e| e.is_a?(klass) }
     end
 
-    # Is `inner` contained in `outer`? Endpoint containment, honouring
-    # `#exclude_end?` on BOTH sides — `cover?` alone would reject `(1...5)` inside
-    # `(0...5)` for an endpoint (`5`) that `inner` does not actually include.
-    # Ruby has no exclusive BEGIN, so the low end stays a plain `cover?`.
-    #
-    # Conservative where containment needs discreteness: `(1...5) <= (0..4)` stays
-    # false, since `4.5` separates them for a non-integer base.
+    # Tests endpoint containment while respecting exclusive ends.
+    # @param inner [Range]
+    # @param outer [Range]
+    # @return [Boolean]
     def range_in_range?(inner, outer)
       lo_ok = outer.begin.nil? || (!inner.begin.nil? && outer.cover?(inner.begin))
       lo_ok && range_end_within?(inner, outer)
@@ -232,10 +211,7 @@ module Plumb
       cmp = inner.end <=> outer.end
       return false if cmp.nil? # incomparable endpoints prove nothing
 
-      # `inner` reaches its end while `outer` stops short of the same value, so
-      # inner's end must fall strictly inside. Every other combination — both
-      # exclusive, both inclusive, or inner exclusive inside an inclusive outer —
-      # is satisfied by `<=`.
+      # An inclusive inner end must fall strictly below an exclusive outer end.
       if !inner.exclude_end? && outer.exclude_end?
         cmp.negative?
       else
@@ -243,9 +219,7 @@ module Plumb
       end
     end
 
-    # Regexps are equal when they match the same strings. `#source` alone is not
-    # that: `i`, `m` and `x` change what a pattern accepts (`/a/i` matches `'A'`,
-    # `/a/` does not), and `#options` is where they live.
+    # Compares Regexp source and semantic options.
     def regex_equal?(a, b)
       a.is_a?(::Regexp) && b.is_a?(::Regexp) && a.source == b.source && a.options == b.options
     end
@@ -274,12 +248,7 @@ module Plumb
       accepted = accepted_type(right)
       return if accepted.is_a?(AnyClass) || subtype?(produced, accepted)
 
-      # Retry reading a produced record as CLOSED. A Hash schema describes incoming
-      # hashes, which may carry keys it ignores — so it is deliberately NOT a subtype
-      # of a consumer that constrains those keys. What it EMITS is narrower: #call
-      # copies over only the keys it declares. So `Hash[name: String] >>
-      # Hash[name: String, age?: Integer]` composes (no `age` can reach the
-      # consumer) while the schema-level relation stays strict. @see HashClass#closed
+      # Produced literal-key records are closed because #call drops undeclared keys.
       return if produced.is_a?(HashClass) && subtype?(produced.closed, accepted)
 
       raise Plumb::TypeError,
@@ -353,14 +322,13 @@ module Plumb
         (disjoint_atomic?(a, b) ? Types::Never : nil)
     end
 
-    # Distribute `&` over a union: intersect each branch with `other`, drop the
-    # branches that go Never, and rejoin the survivors with `|`. All-Never ⇒
-    # Never. A branch the reducer can't fold becomes a runtime And.
-    # `union_first` records which side the union came from, so each branch is
-    # recombined in the ORIGINAL order. It matters whenever a branch cannot be
-    # folded: the fallback is Conjunction.build, which for a converting operand is a
-    # SEQUENTIAL And, and `And(Static[5], String)` is not `And(String, Static[5])` —
-    # the first emits 5 and then checks it, the second checks the input first.
+    # Distributes intersection over a union, preserving operand order for runtime
+    # compositions and dropping branches that reduce to Never. Order is observable
+    # when a fallback branch converts: `Static[5] >> String` is not `String >> Static[5]`.
+    # @param union [Disjunction]
+    # @param other [Composable]
+    # @param union_first [Boolean] whether the union was the left operand
+    # @return [Composable]
     def intersect_union(union, other, union_first: true)
       parts = union.children.filter_map do |branch|
         left, right = union_first ? [branch, other] : [other, branch]
@@ -466,23 +434,11 @@ module Plumb
     # @return [Composable] `type` itself, or a rebuilt container
     def map_children(type, &blk) = NodeMapper.map_children(type, &blk)
 
-    # Are two leaf types provably disjoint? True when NO pair of their underlying
-    # Ruby base types is subtype-related — so no value can be an instance of both
-    # (`Types::String & Types::Integer` ⇒ Never). Conservative: an unknown base
-    # (opaque matcher ⇒ empty base-type list) is NOT provably disjoint, so the
-    # caller keeps a runtime And rather than wrongly collapsing to Never.
+    # Tests whether two stable, known domains have no related base classes.
+    # @param a [Composable]
+    # @param b [Composable]
+    # @return [Boolean]
     def disjoint_atomic?(a, b)
-      # Only judge two nodes that both return their input unchanged.
-      #
-      # "No value satisfies both" is the right question for a genuine meet, where
-      # each side describes the SAME value. It is the wrong question everywhere
-      # else, and Plumb.resolve_base_types answers about what a node PRODUCES: a
-      # Function reports its output type, a Static the class of the fixed value it
-      # returns whatever its input, a Not the very classes it excludes. Judging
-      # those sinks an inhabited intersection to Never — `Types::Integer &
-      # Types::Integer.transform(::String, &:to_s)` accepts every Integer, and
-      # `Types::String & Types::Not[Types::Integer]` accepts every String.
-      #
       abt = stable_domain(a)
       bbt = stable_domain(b)
       return false if abt.nil? || bbt.nil?
@@ -490,31 +446,14 @@ module Plumb
       abt.none? { |x| bbt.any? { |y| class_le?(x, y) || class_le?(y, x) } }
     end
 
-    # The Ruby classes `type` accepts, but ONLY when they are also the classes it
-    # produces — ie. the node NARROWS one domain rather than moving between two.
-    # nil for anything else, including an unknown domain.
-    #
-    # That distinction is what makes #disjoint_atomic? answerable. "No value
-    # satisfies both" is a question about a single domain, so it can only be asked
-    # of a node that has one. A converting node has two, and Plumb.resolve_base_types
-    # reports only the produced side — which is how `Types::Integer &
-    # Types::Integer.transform(::String, &:to_s)` came to look disjoint (Integer vs
-    # String) though its And accepts every Integer. A Static reports the class of
-    # the value it emits regardless of input, and a Not reports the very classes it
-    # excludes; neither has a domain to compare either.
-    #
-    # Declining here costs only precision: the caller keeps a runtime intersection
-    # where it might have proved Never. That matches what `&` already does for a
-    # converting side — Conjunction.build keeps both — while a wrong Never discards
-    # the whole composition.
+    # Returns the shared accepted/output base classes for a non-converting type.
+    # Unknown or converting domains return nil; comparing their output classes as
+    # input domains could incorrectly reduce an inhabited intersection to Never.
+    # @param type [Composable]
+    # @return [Array<Class>, nil]
     def stable_domain(type)
       consumes = accepted_type(type)
-      # A converting node that cannot describe its input falls back to reporting
-      # ITSELF as what it accepts, which then resolves to what it PRODUCES — so the
-      # two look identical while genuinely differing. A Types::Data class is the
-      # case in point: it takes a Hash and returns an instance, but answers `self`
-      # on both sides, which would make it look disjoint from Types::Hash and sink
-      # `Types::Hash & Person` to Never. Unknown, so decline.
+      # A converting self-fallback does not expose a reliable input domain.
       return nil if consumes.equal?(type) && !value_preserving?(type)
 
       accepted = Plumb.resolve_base_types(consumes)

--- a/lib/plumb/tagged_hash.rb
+++ b/lib/plumb/tagged_hash.rb
@@ -24,9 +24,16 @@ module Plumb
       # types are assumed to have literal values for the index field :key
       @index = @children.each.with_object({}) do |t, memo|
         key_type = t.at_key(@key)
-        raise ParseError, "key type at :#{@key} #{key_type} must be a Constraint" unless key_type.is_a?(Constraint)
+        # What a discriminator needs is the literal it matches, whichever node
+        # carries it — a bare literal is a ValueClass, one narrowed by a base
+        # (`Types::String['event']`) is a Constraint. Subtyping.literal_value reads
+        # both and returns Undefined for anything matching more than one value.
+        tag = Plumb::Subtyping.literal_value(key_type)
+        if Undefined.equal?(tag)
+          raise ParseError, "key type at :#{@key} #{key_type} must match a single literal value"
+        end
 
-        memo[key_type.children[0]] = t
+        memo[tag] = t
       end
 
       freeze
@@ -37,6 +44,36 @@ module Plumb
     # the rebuilt TaggedHash still satisfies its "tag key is a Constraint"
     # invariant. Lets `Type >> Codec` (which builds a rewritten variant with a
     # converting field) type-check against the output tagged hash.
+    # Identified by the discriminator key and the Hash it narrows as well as by its
+    # variants. #children holds only the variants, so a structural comparison would
+    # find two TaggedHashes equal while they were keyed on different fields, or
+    # narrowing different base Hashes — and `==` is what
+    # Plumb::Subtyping.subtype? consults first, so that would make them mutual
+    # subtypes. `Key#eql?` is the key comparison (Key defines no #==) and
+    # deliberately ignores optionality, which a discriminator never uses.
+    def ==(other)
+      other.instance_of?(self.class) &&
+        key.eql?(other.key) &&
+        hash_type == other.hash_type &&
+        children == other.children
+    end
+
+    # A TaggedHash resolves to ONE of its variants: #call runs @hash_type and then
+    # the variant selected by the discriminator, so the value it returns is
+    # whatever that variant produced. It is therefore a subtype of anything EVERY
+    # variant is a subtype of — which makes it a subtype of the "any Hash" top,
+    # like the rest of the Hash family.
+    #
+    # Deliberately conservative: it ignores that @hash_type also had to pass, which
+    # can only make the real value set narrower, never wider. Without this the
+    # default covariant rule would compare variant lists alone and call two
+    # TaggedHashes over different base Hashes mutual subtypes.
+    def subtype_of?(other)
+      return true if self == other
+
+      @children.all? { |variant| Plumb::Subtyping.subtype?(variant, other) }
+    end
+
     def accepted_type
       relaxed = @children.map do |child|
         schema = child._schema.each_with_object({}) do |(k, field), h|

--- a/lib/plumb/tagged_hash.rb
+++ b/lib/plumb/tagged_hash.rb
@@ -24,10 +24,7 @@ module Plumb
       # types are assumed to have literal values for the index field :key
       @index = @children.each.with_object({}) do |t, memo|
         key_type = t.at_key(@key)
-        # What a discriminator needs is the literal it matches, whichever node
-        # carries it — a bare literal is a ValueClass, one narrowed by a base
-        # (`Types::String['event']`) is a Constraint. Subtyping.literal_value reads
-        # both and returns Undefined for anything matching more than one value.
+        # Accept either bare or base-constrained single-value tags.
         tag = Plumb::Subtyping.literal_value(key_type)
         if Undefined.equal?(tag)
           raise ParseError, "key type at :#{@key} #{key_type} must match a single literal value"
@@ -39,18 +36,10 @@ module Plumb
       freeze
     end
 
-    # As a consumer, relax each variant's fields to what they accept (like
-    # HashClass#accepted_type) — but keep the discriminator field literal, so
-    # the rebuilt TaggedHash still satisfies its "tag key is a Constraint"
-    # invariant. Lets `Type >> Codec` (which builds a rewritten variant with a
-    # converting field) type-check against the output tagged hash.
-    # Identified by the discriminator key and the Hash it narrows as well as by its
-    # variants. #children holds only the variants, so a structural comparison would
-    # find two TaggedHashes equal while they were keyed on different fields, or
-    # narrowing different base Hashes — and `==` is what
-    # Plumb::Subtyping.subtype? consults first, so that would make them mutual
-    # subtypes. `Key#eql?` is the key comparison (Key defines no #==) and
-    # deliberately ignores optionality, which a discriminator never uses.
+    # Equality includes the discriminator and base hash because #children contains
+    # only variants; comparing children alone would conflate distinct tagged hashes.
+    # @param other [Object]
+    # @return [Boolean]
     def ==(other)
       other.instance_of?(self.class) &&
         key.eql?(other.key) &&
@@ -58,22 +47,19 @@ module Plumb
         children == other.children
     end
 
-    # A TaggedHash resolves to ONE of its variants: #call runs @hash_type and then
-    # the variant selected by the discriminator, so the value it returns is
-    # whatever that variant produced. It is therefore a subtype of anything EVERY
-    # variant is a subtype of — which makes it a subtype of the "any Hash" top,
-    # like the rest of the Hash family.
-    #
-    # Deliberately conservative: it ignores that @hash_type also had to pass, which
-    # can only make the real value set narrower, never wider. Without this the
-    # default covariant rule would compare variant lists alone and call two
-    # TaggedHashes over different base Hashes mutual subtypes.
+    # A tagged hash is a subtype when every selectable variant is a subtype. The
+    # base hash only narrows those variants, so ignoring it here is conservative;
+    # comparing variants pairwise would be unsound across different discriminators.
+    # @param other [Composable]
+    # @return [Boolean]
     def subtype_of?(other)
       return true if self == other
 
       @children.all? { |variant| Plumb::Subtyping.subtype?(variant, other) }
     end
 
+    # Relaxes each variant's non-discriminator fields to their accepted types.
+    # @return [TaggedHash]
     def accepted_type
       relaxed = @children.map do |child|
         schema = child._schema.each_with_object({}) do |(k, field), h|

--- a/spec/relation_spec.rb
+++ b/spec/relation_spec.rb
@@ -1,0 +1,107 @@
+# frozen_string_literal: true
+
+require 'set'
+require 'spec_helper'
+
+RSpec.describe 'semantic matcher relations' do
+  module RelationTypes
+    include Plumb::Types
+  end
+
+  it 'keeps the public Constraint matcher raw while applying range semantics' do
+    matcher = 1..3
+    constraint = Plumb::Constraint.new(matcher)
+
+    expect(constraint.matcher).to equal(matcher)
+    expect(constraint.children.first).to equal(matcher)
+    expect(constraint <= Plumb::Constraint.new(0..4)).to be(true)
+    expect(constraint <= Plumb::Constraint.new(2..4)).to be(false)
+  end
+
+  it 'compares supported matcher kinds through the public type relation' do
+    expect(RelationTypes::Any[::Integer] <= RelationTypes::Any[::Numeric]).to be(true)
+    expect(RelationTypes::Any[1] <= RelationTypes::Any[1..3]).to be(true)
+    expect(RelationTypes::Any['ax'] <= RelationTypes::Any[/a/]).to be(true)
+    expect(RelationTypes::Any[Set[1, 2]] <= RelationTypes::Any[Set[1, 2, 3]]).to be(true)
+    expect(RelationTypes::Any[2..5] <= RelationTypes::Any[1..10]).to be(true)
+  end
+
+  it 'rejects disproven matcher relationships' do
+    expect(RelationTypes::Any[::Numeric] <= RelationTypes::Any[::Integer]).to be(false)
+    expect(RelationTypes::Any[Set[1, 4]] <= RelationTypes::Any[Set[1, 2, 3]]).to be(false)
+    expect(RelationTypes::Any[0..5] <= RelationTypes::Any[1..10]).to be(false)
+  end
+
+  it 'merges compatible matcher intersections' do
+    range = RelationTypes::Any[1..5][3..8]
+    set = RelationTypes::Any[Set[1, 2]][Set[2, 3]]
+    patterns = RelationTypes::Any[/a/][/b/]
+
+    expect(range).to be_a(Plumb::Constraint)
+    expect(range.matcher).to eq(3..5)
+    expect(set).to be_a(Plumb::Constraint)
+    expect(set.matcher).to eq(Set[2])
+    expect(patterns.resolve('ab')).to be_valid
+    expect(patterns.resolve('a')).not_to be_valid
+  end
+
+  it 'uses known matcher domains to reject incompatible refinements' do
+    expect { RelationTypes::Integer[/x/] }.to raise_error(Plumb::TypeError)
+    expect { RelationTypes::String[1..3] }.to raise_error(Plumb::TypeError)
+    expect { RelationTypes::Integer[Set[1, 'x']] }.not_to raise_error
+    expect { RelationTypes::Integer[proc { true }] }.not_to raise_error
+  end
+
+  it 'does not claim incomparable Range relationships as subtypes' do
+    expect(RelationTypes::Any[1..3] <= RelationTypes::Any[..'z']).to be(false)
+  end
+
+  it 'does not claim unsupported matcher collaborations as subtypes' do
+    expect(RelationTypes::Any[Set['a']] <= RelationTypes::Any[/a/]).to be(false)
+    expect(RelationTypes::Any[proc { true }] <= RelationTypes::Any[::Proc]).to be(false)
+  end
+
+  it 'keeps unsupported matcher pairs as runtime intersections' do
+    intersection = Plumb::Constraint.new(Set['a']) & Plumb::Constraint.new(/a/)
+
+    expect(intersection).to be_a(Plumb::Intersection)
+    expect(intersection.resolve('a')).to be_valid
+    expect(intersection.resolve('b')).not_to be_valid
+  end
+
+  it 'does not call unrelated mixin Modules disjoint' do
+    left = Module.new
+    right = Module.new
+    both = Class.new do
+      include left
+      include right
+    end
+
+    intersection = Plumb::Constraint.new(left) & Plumb::Constraint.new(right)
+
+    expect(intersection).to be_a(Plumb::Intersection)
+    expect(intersection.resolve(both.new)).to be_valid
+  end
+
+  it 'does not treat an opaque comparison as a disjointness proof' do
+    positive = RelationTypes::Integer.check('positive') { |value| value.positive? }
+    even = RelationTypes::Integer.check('even') { |value| value.even? }
+
+    intersection = positive & even
+
+    expect(intersection).to be_a(Plumb::Intersection)
+    expect(intersection.resolve(2)).to be_valid
+    expect(intersection.resolve(1)).not_to be_valid
+    expect(intersection.resolve(-2)).not_to be_valid
+  end
+
+  it 'keeps opaque matchers as runtime refinements of a known base' do
+    matcher = Object.new
+    def matcher.===(value) = value == 2
+
+    type = RelationTypes::Integer[matcher]
+
+    expect(type.resolve(2)).to be_valid
+    expect(type.resolve(3)).not_to be_valid
+  end
+end

--- a/spec/subtype_laws_spec.rb
+++ b/spec/subtype_laws_spec.rb
@@ -1,0 +1,531 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'set'
+
+# PROPERTY LAWS relating the TYPE ALGEBRA to the RUNTIME.
+#
+# spec/invariants_spec.rb pins what `<=` currently answers (a snapshot) and the
+# lattice laws it must obey (reflexivity, transitivity, top, bottom). Those are
+# statements about the relation on its own terms: they can all hold while the
+# relation says something the data flatly contradicts.
+#
+# This file closes that gap. Every law here is a statement about ACCEPTED VALUES,
+# checked by running `#resolve` over a witness corpus. `subtype?(a, b)` claims
+# "every value `a` describes, `b` describes too" — so if some witness passes `a`
+# and fails `b`, the relation is wrong about the data, whatever the algebra says.
+#
+# That matters because `<=` is not advisory. Four consumers act on it, and each
+# turns a wrong verdict into wrong VALIDATION:
+#
+#   Optimizer.reduce_step / redundant_refinement?  deletes a runtime check
+#   Optimizer.reduce_union                         drops a union branch
+#   Subtyping.intersect                            drops a meet operand
+#   Subtyping.check_composable!                    admits an always-failing chain
+#
+# So the composition laws (JOIN / MEET / SEQUENCE below) are the ones with teeth:
+# they catch a bad verdict at the point where it has already changed behaviour.
+#
+# RULES OF ENGAGEMENT
+#
+#   - These laws are an ORACLE, not a snapshot. There is deliberately no
+#     allowlist to regenerate: a failure means a type's declared relation and its
+#     `#call` disagree, and the fix belongs in the type, not here.
+#
+#   - Each law reports EVERY violating pair with the concrete witness value, so
+#     one run enumerates the whole class of failure rather than the first case.
+#
+#   - Witnesses are compared BY POSITION, never by `==`. `5 == 5.0` in Ruby, so
+#     an accepted-set built with `Array#include?` would silently conflate exactly
+#     the cross-class equality some of these laws exist to test.
+#
+#   - A specimen whose `#resolve` raises is treated as REJECTING that witness, so
+#     one raising type doesn't contaminate the other laws. RESOLVE TOTALITY below
+#     is what reports the raise.
+#
+# ADDING A SPECIMEN: prefer one that is structurally unlike what is already
+# there — a wrapper, a negation, a recursive type, an open record. The laws are
+# only as strong as the grid, and a near-duplicate specimen buys nothing.
+RSpec.describe 'subtype relation vs runtime behaviour' do
+  # ---------------------------------------------------------------------------
+  # Witness corpus
+  # ---------------------------------------------------------------------------
+
+  # A stable stand-in for "an object satisfying no matcher in the grid" — a bare
+  # Object.new would inspect as a different address on every run, making failure
+  # output unstable.
+  OPAQUE = Object.new
+  def OPAQUE.inspect = '#<opaque>'
+  OPAQUE.freeze
+
+  WITNESSES = [
+    Plumb::Undefined,
+    nil, true, false,
+    0, 1, 2, 5, 10, 18, 50, 99, 100, 101, -1,
+    5.0, 2.5, 99.5, 100.0,
+    'a', 'A', 'ab', 'abcd', '', '42', 'a@b.com',
+    :a, :xyz,
+    [], [1], [1, 2], ['a'], [1, 'a'],
+    {}, { a: 1 }, { a: 'x' }, { a: 1, b: 'x' }, { name: 'a', age: 1 },
+    { name: 'a', age: 'x' }, { 'id_1' => 'x' }, { v: 1, n: nil },
+    (1..3), ::Set[1, 2], OPAQUE
+  ].freeze
+
+  # ---------------------------------------------------------------------------
+  # Specimen grid
+  # ---------------------------------------------------------------------------
+
+  # Recursive records, to exercise Deferred through the relation rather than only
+  # through #resolve. IntList and StrList are structurally DIFFERENT types; any
+  # law that finds them interchangeable has found a bug.
+  IntList = Types::Hash[v: Types::Integer, n: Types::Nil | Types::Any.defer { IntList }]
+  StrList = Types::Hash[v: Types::String,  n: Types::Nil | Types::Any.defer { StrList }]
+
+  PersonStruct = Types::Data[name: Types::String, age: Types::Integer]
+
+  # A refinement stacked on a CONVERSION. `#[]` re-parents into a Constraint whose
+  # base is the transform, so this node converts while presenting as a matcher.
+  COERCE_AGE = Types::String.transform(::Integer, :to_i)[0..150]
+
+  SPECIMENS = {
+    # tops, bottoms, and the odd one out
+    'Any' => Types::Any,
+    'Never' => Types::Never,
+    'Undefined' => Types::Undefined,
+    'Interface[]' => Types::Interface[],
+
+    # scalars
+    'String' => Types::String,
+    'Integer' => Types::Integer,
+    'Numeric' => Types::Numeric,
+    'Float' => Types::Float,
+    'Symbol' => Types::Symbol,
+    'Nil' => Types::Nil,
+    'Boolean' => Types::Boolean,
+
+    # refinements — ranges (inclusive AND exclusive: range_in_range? must respect
+    # #exclude_end?, and Constraint.intersect_ranges already does)
+    'Integer[0..100]' => Types::Integer[0..100],
+    'Integer[10..]' => Types::Integer[10..],
+    'Integer[0...100]' => Types::Integer[0...100],
+    'Integer[1...5]' => Types::Integer[1...5],
+    'Integer[0...5]' => Types::Integer[0...5],
+
+    # refinements — regexp. Options are semantically load-bearing, so /a/ and
+    # /a/i must NOT be interchangeable.
+    'String[/a/]' => Types::String[/a/],
+    'String[/a/i]' => Types::String[/a/i],
+    'String.where(size: 1..3)' => Types::String.where(size: 1..3),
+
+    # literals, both spellings. ValueClass matches by `==`, so its inhabitants are
+    # `{v | v == 5}` — which in Ruby includes 5.0.
+    'Value[5]' => Types::Value[5],
+    'Value[5.0]' => Types::Value[5.0],
+    'Any[5]' => Types::Any[5],
+    'Static[5]' => Types::Static[5],
+
+    # joins and meets
+    'String|Integer' => Types::String | Types::Integer,
+    'Integer.nullable' => Types::Integer.nullable,
+    'Integer[0..100]&Integer[10..]' => Types::Integer[0..100] & Types::Integer[10..],
+
+    # negation — must be CONTRAvariant
+    'Not[Integer]' => Types::Not[Types::Integer],
+    'Not[Numeric]' => Types::Not[Types::Numeric],
+
+    # transparent wrappers. `subtype?` sees through these, and the reductions must
+    # not treat two wrappers of DISJOINT types as interchangeable.
+    'String.present' => Types::String.present,
+    'Integer.present' => Types::Integer.present,
+    'Integer[1..10].metadata' => Types::Integer[1..10].metadata(lab: 'x'),
+    'Integer[100..200].metadata' => Types::Integer[100..200].metadata(lab: 'x'),
+    'defer{Integer}' => Types::Any.defer { Types::Integer },
+    'defer{String}' => Types::Any.defer { Types::String },
+
+    # containers
+    'Array[Integer]' => Types::Array[Types::Integer],
+    'Array[Numeric]' => Types::Array[Types::Numeric],
+    'Tuple[Integer,String]' => Types::Tuple[Types::Integer, Types::String],
+
+    # records: the bare "any Hash" top, closed, open, and pattern-keyed
+    'Hash' => Types::Hash,
+    'Hash[a:Integer]' => Types::Hash[a: Types::Integer],
+    'Hash[a:Numeric]' => Types::Hash[a: Types::Numeric],
+    'Hash[a?:Integer]' => Types::Hash[:'a?' => Types::Integer],
+    'Hash[_:Integer]' => Types::Hash[_: Types::Integer],
+    'Hash[/^id_/:Integer]' => Types::Hash[Types::String[/^id_/] => Types::Integer],
+    'HashMap[Symbol,Integer]' => Types::Hash[Types::Symbol, Types::Integer],
+
+    # conversions, and a conversion wearing a matcher's clothes
+    'String->Integer' => Types::String.transform(::Integer, :to_i),
+    'coerce_age' => COERCE_AGE,
+
+    # A transform whose block returns something other than its declared output.
+    # Function#call deliberately validates the produced value rather than trusting
+    # the declaration, so the library's defined answer here is an INVALID result —
+    # which makes this a fair specimen, and the one that catches a reduction
+    # removing that check at a composition seam.
+    'String->Integer(lying)' => Types::String.transform(::Integer) { |s| s },
+
+    # A downstream consumer for the transforms above, so a `>>` between two typed
+    # steps reaches Function#fuse_with — the seam where a declared output type is
+    # trusted instead of checked.
+    'Integer->String' => Types::Integer.transform(::String, &:to_s),
+
+    # recursive + struct
+    'IntList' => IntList,
+    'StrList' => StrList,
+    'PersonStruct' => PersonStruct,
+    'Hash[name:String,age:Integer]' => Types::Hash[name: Types::String, age: Types::Integer]
+  }.freeze
+
+  LABELS = SPECIMENS.keys.freeze
+
+  # ---------------------------------------------------------------------------
+  # Probing
+  # ---------------------------------------------------------------------------
+
+  # Witness indices `type` accepts, plus the indices where `#resolve` RAISED
+  # instead of returning a Result. A raise counts as a rejection for every other
+  # law (see RULES OF ENGAGEMENT) and is reported once, by RESOLVE TOTALITY.
+  def self.probe(type)
+    accepted = Set.new
+    raised = {}
+    WITNESSES.each_index do |i|
+      begin
+        result = type.resolve(WITNESSES[i])
+      rescue StandardError => e
+        raised[i] = "#{e.class}: #{e.message}"
+        next
+      end
+      accepted << i if result.valid?
+    end
+    [accepted, raised]
+  end
+
+  PROBED = SPECIMENS.transform_values { |t| probe(t) }.freeze
+  ACCEPTS = PROBED.transform_values(&:first).freeze
+  RAISED = PROBED.transform_values(&:last).freeze
+
+  def self.witness(index) = "#{WITNESSES[index].inspect} (#{WITNESSES[index].class})"
+
+  # Name at most a handful of witnesses per violation. One counterexample proves
+  # the law broken; a full corpus dump per line buries the next violation.
+  def self.witnesses(indices, limit: 4)
+    named = indices.to_a.first(limit).map { |i| witness(i) }
+    extra = indices.size - named.size
+    extra.positive? ? "#{named.join(', ')} (+#{extra} more)" : named.join(', ')
+  end
+
+  # `Types::Any` is not a join identity by construction: AnyClass#| is a documented
+  # BUILDER shortcut (`Any | X == X`, mirroring `Any[String] == String`), so it
+  # deliberately discards the top rather than absorbing. Excluded from the union
+  # laws, which would otherwise report a design decision as a bug.
+  def self.builder_shortcut?(type) = type.is_a?(Plumb::AnyClass)
+
+  # Build `expr` (a composition), or nil when the checker refuses it. A refused
+  # composition is the checker working, not a violation — the laws below only
+  # constrain chains that were actually built.
+  def self.build
+    yield
+  rescue Plumb::TypeError
+    nil
+  end
+
+  def report(violations)
+    return if violations.empty?
+
+    raise RSpec::Expectations::ExpectationNotMetError,
+          "#{violations.size} violation(s):\n  - #{violations.join("\n  - ")}"
+  end
+
+  # ---------------------------------------------------------------------------
+  # THE LAWS
+  # ---------------------------------------------------------------------------
+
+  # `#resolve` is total: every type turns a value into a Result, and reports a
+  # mismatch as an invalid Result rather than by raising. A type that raises can't
+  # be composed defensively — the caller has no Result to inspect.
+  describe 'RESOLVE TOTALITY' do
+    it 'never raises, for any specimen and any witness' do
+      violations = LABELS.flat_map do |label|
+        RAISED[label].map { |i, err| "#{label}.resolve(#{self.class.witness(i)}) raised #{err}" }
+      end
+
+      report(violations)
+    end
+  end
+
+  # THE central law. `subtype?(a, b)` asserts every value `a` describes is
+  # described by `b`; scoped to value-preserving types, where "describes" is
+  # exactly "accepts and returns unchanged", that is literally set inclusion.
+  #
+  # A converting type is excluded because it is deliberately identified by what it
+  # PRODUCES, not what it consumes (Subtyping#subtype_identity) — so its accepted
+  # set is not what the relation is talking about.
+  describe 'SUBTYPE SOUNDNESS' do
+    it 'never claims a <= b while b rejects a value a accepts' do
+      violations = []
+      LABELS.each do |a|
+        next unless Plumb::Subtyping.value_preserving?(SPECIMENS[a])
+
+        LABELS.each do |b|
+          next if a == b
+          next unless Plumb::Subtyping.value_preserving?(SPECIMENS[b])
+          next unless Plumb::Subtyping.subtype?(SPECIMENS[a], SPECIMENS[b])
+
+          bad = ACCEPTS[a] - ACCEPTS[b]
+          violations << "#{a} <= #{b}, but #{b} rejects: #{self.class.witnesses(bad)}" if bad.any?
+        end
+      end
+
+      report(violations)
+    end
+  end
+
+  # Mutual subtypes are the same type as far as the relation can tell, so every
+  # reduction is free to swap one for the other. If their accepted sets differ,
+  # some reduction will silently change what validates.
+  #
+  # This is where a node that inherits `Equality#==` while keeping its identity in
+  # ivars shows up: `==` compares class + #children, `subtype?` short-circuits on
+  # `a == b`, and the wrapper guards never run.
+  describe 'EQUIVALENCE' do
+    it 'gives mutual subtypes the same accepted set' do
+      violations = []
+      seen = Set.new
+      LABELS.each do |a|
+        next unless Plumb::Subtyping.value_preserving?(SPECIMENS[a])
+
+        LABELS.each do |b|
+          next if a == b || seen.include?(Set[a, b])
+          next unless Plumb::Subtyping.value_preserving?(SPECIMENS[b])
+          next unless Plumb::Subtyping.equivalent?(SPECIMENS[a], SPECIMENS[b])
+
+          seen << Set[a, b]
+          only_a = ACCEPTS[a] - ACCEPTS[b]
+          only_b = ACCEPTS[b] - ACCEPTS[a]
+          next if only_a.empty? && only_b.empty?
+
+          violations << "#{a} and #{b} are mutual subtypes, but only #{a} accepts " \
+                        "[#{self.class.witnesses(only_a)}] and only #{b} accepts " \
+                        "[#{self.class.witnesses(only_b)}]"
+        end
+      end
+
+      report(violations)
+    end
+  end
+
+  # `a | b` is a JOIN: Disjunction#call tries `a`, then retries `b` on the
+  # original value, so the union accepts everything EITHER branch accepts.
+  # Reduction may rewrite the node; it may not shrink that set.
+  #
+  # Holds for every pair, converting branches included — this is about the values
+  # the built node accepts, not about identity.
+  describe 'JOIN' do
+    it 'never accepts less than either branch' do
+      violations = []
+      LABELS.each do |a|
+        next if self.class.builder_shortcut?(SPECIMENS[a])
+
+        LABELS.each do |b|
+          next if a == b
+
+          union = self.class.build { SPECIMENS[a] | SPECIMENS[b] }
+          next if union.nil?
+
+          accepted, = self.class.probe(union)
+          lost = (ACCEPTS[a] | ACCEPTS[b]) - accepted
+          violations << "(#{a} | #{b}) => #{union.inspect} rejects: #{self.class.witnesses(lost)}" if lost.any?
+        end
+      end
+
+      report(violations)
+    end
+  end
+
+  # `a & b` is a MEET: it must accept only what BOTH accept.
+  #
+  # Gated on both sides being value-preserving, because that is exactly when
+  # Conjunction.build yields an Intersection. When either side converts it builds
+  # an And instead, whose `#call` is SEQUENTIAL (`result.map(@left).map(@right)`,
+  # so the right sees the left's OUTPUT) — a pipeline, legitimately not a meet.
+  #
+  # Note the gate consults `value_preserving?`, so a node that MISREPORTS itself
+  # as value-preserving is judged by the meet law it claims to obey.
+  describe 'MEET' do
+    it 'never accepts what either side rejects' do
+      violations = []
+      LABELS.each do |a|
+        next unless Plumb::Subtyping.value_preserving?(SPECIMENS[a])
+
+        LABELS.each do |b|
+          next if a == b
+          next unless Plumb::Subtyping.value_preserving?(SPECIMENS[b])
+
+          meet = self.class.build { SPECIMENS[a] & SPECIMENS[b] }
+          next if meet.nil?
+
+          accepted, = self.class.probe(meet)
+          extra = accepted - (ACCEPTS[a] & ACCEPTS[b])
+          violations << "(#{a} & #{b}) => #{meet.inspect} accepts: #{self.class.witnesses(extra)}" if extra.any?
+        end
+      end
+
+      report(violations)
+    end
+  end
+
+  # `a >> b` runs `a` first, and `Result#map` short-circuits on an invalid result,
+  # so the chain CANNOT accept what `a` rejects. Unconditional — no gate, no
+  # exceptions.
+  #
+  # This is the law that catches a reduction removing a check it believed
+  # redundant: composing must never turn an invalid value into a valid one.
+  describe 'SEQUENCE' do
+    it 'never accepts what its left side rejects' do
+      violations = []
+      LABELS.each do |a|
+        LABELS.each do |b|
+          next if a == b
+
+          chain = self.class.build { SPECIMENS[a] >> SPECIMENS[b] }
+          next if chain.nil?
+
+          accepted, = self.class.probe(chain)
+          widened = accepted - ACCEPTS[a]
+          violations << "(#{a} >> #{b}) => #{chain.inspect} accepts: #{self.class.witnesses(widened)}" if widened.any?
+        end
+      end
+
+      report(violations)
+    end
+  end
+
+  # REDUCTION FIDELITY — the strongest laws here, and the ones aimed squarely at
+  # the four consumers named at the top of this file.
+  #
+  # Every operator has an UNREDUCED form: the node that would exist if the
+  # Optimizer did nothing (`And`/`Or`/`Conjunction.build`). Reduction exists to
+  # make the tree cheaper, never to change what it accepts — so the reduced node
+  # and the unreduced one must accept EXACTLY the same values.
+  #
+  # This catches what SEQUENCE structurally cannot. Deleting the right-hand side of
+  # a chain doesn't widen the chain past its LEFT side, so `a >> b` collapsing to
+  # `a` slips through an "accepts no more than `a`" check while having silently
+  # discarded `b`'s validation. Comparing against `And.new(a, b)` sees it.
+  describe 'REDUCTION FIDELITY' do
+    # Shared driver: build both forms, compare accepted sets, describe the drift.
+    def self.fidelity_violations(op_label, skip_left: nil)
+      violations = []
+      LABELS.each do |a|
+        next if skip_left && skip_left.call(SPECIMENS[a])
+
+        LABELS.each do |b|
+          next if a == b
+
+          reduced = build { yield(:reduced, SPECIMENS[a], SPECIMENS[b]) }
+          next if reduced.nil?
+
+          reference = build { yield(:reference, SPECIMENS[a], SPECIMENS[b]) }
+          next if reference.nil?
+
+          got, = probe(reduced)
+          want, = probe(reference)
+          next if got == want
+
+          detail = []
+          detail << "no longer accepts #{witnesses(want - got)}" if (want - got).any?
+          detail << "now also accepts #{witnesses(got - want)}" if (got - want).any?
+          violations << "#{a} #{op_label} #{b} reduced to #{reduced.inspect}, which #{detail.join(' and ')}"
+        end
+      end
+      violations
+    end
+
+    it 'preserves the accepted set when reducing a >> chain' do
+      report(self.class.fidelity_violations('>>') do |form, a, b|
+        form == :reduced ? a >> b : Plumb::And.new(a, b)
+      end)
+    end
+
+    it 'preserves the accepted set when reducing a | union' do
+      report(self.class.fidelity_violations('|', skip_left: ->(t) { t.is_a?(Plumb::AnyClass) }) do |form, a, b|
+        form == :reduced ? a | b : Plumb::Or.new(a, b)
+      end)
+    end
+
+    it 'preserves the accepted set when reducing an & intersection' do
+      report(self.class.fidelity_violations('&') do |form, a, b|
+        form == :reduced ? a & b : Plumb::Conjunction.build(a, b)
+      end)
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Lattice laws, over the grid above
+  # ---------------------------------------------------------------------------
+
+  # These are the same laws spec/invariants_spec.rb asserts, re-run over a grid
+  # that deliberately includes what that one leaves out: the bare `Types::Hash`
+  # top, literal ValueClass types, Not, Deferred, and the Policy/Metadata
+  # wrappers. Kept here rather than added there so the two files stay
+  # independently readable — that one snapshots a relation, this one stress-tests
+  # it.
+  describe 'LATTICE' do
+    it 'is reflexive' do
+      report(LABELS.reject { |l| Plumb::Subtyping.subtype?(SPECIMENS[l], SPECIMENS[l]) }
+                   .map { |l| "#{l} is not a subtype of itself" })
+    end
+
+    it 'has Any as top' do
+      report(LABELS.reject { |l| Plumb::Subtyping.subtype?(SPECIMENS[l], Types::Any) }
+                   .map { |l| "#{l} is not a subtype of Any" })
+    end
+
+    it 'has Never as bottom' do
+      report(LABELS.reject { |l| Plumb::Subtyping.subtype?(Types::Never, SPECIMENS[l]) }
+                   .map { |l| "Never is not a subtype of #{l}" })
+    end
+
+    it 'is transitive' do
+      violations = []
+      LABELS.each do |a|
+        LABELS.each do |b|
+          next unless Plumb::Subtyping.subtype?(SPECIMENS[a], SPECIMENS[b])
+
+          LABELS.each do |c|
+            next unless Plumb::Subtyping.subtype?(SPECIMENS[b], SPECIMENS[c])
+            next if Plumb::Subtyping.subtype?(SPECIMENS[a], SPECIMENS[c])
+
+            violations << "#{a} <= #{b} <= #{c}, but not #{a} <= #{c}"
+          end
+        end
+      end
+
+      report(violations)
+    end
+
+    # No type may sit under two types that share no inhabitant. The pairs are
+    # hardcoded and asserted disjoint over the corpus first — an empirically
+    # overlapping pair would make this vacuous (`Hash[_:Integer]` and
+    # `Hash[_:String]` look disjoint but both accept `{}`).
+    it 'never places a type under two disjoint types' do
+      disjoint = [%w[String Integer], %w[String Numeric], %w[Integer Nil]]
+      disjoint.each do |(x, y)|
+        expect(ACCEPTS[x] & ACCEPTS[y]).to be_empty, "#{x} and #{y} overlap; pick a disjoint pair"
+      end
+
+      violations = LABELS.reject { |l| SPECIMENS[l].is_a?(Plumb::NeverClass) }.flat_map do |label|
+        disjoint.filter_map do |(x, y)|
+          both = Plumb::Subtyping.subtype?(SPECIMENS[label], SPECIMENS[x]) &&
+                 Plumb::Subtyping.subtype?(SPECIMENS[label], SPECIMENS[y])
+          "#{label} is a subtype of both #{x} and #{y}" if both
+        end
+      end
+
+      report(violations)
+    end
+  end
+end

--- a/spec/subtype_laws_spec.rb
+++ b/spec/subtype_laws_spec.rb
@@ -417,13 +417,14 @@ RSpec.describe 'subtype relation vs runtime behaviour' do
   # discarded `b`'s validation. Comparing against `And.new(a, b)` sees it.
   describe 'REDUCTION FIDELITY' do
     # Shared driver: build both forms, compare accepted sets, describe the drift.
-    def self.fidelity_violations(op_label, skip_left: nil)
+    def self.fidelity_violations(op_label, skip_left: nil, skip_pair: nil)
       violations = []
       LABELS.each do |a|
         next if skip_left && skip_left.call(SPECIMENS[a])
 
         LABELS.each do |b|
           next if a == b
+          next if skip_pair && skip_pair.call(SPECIMENS[a], SPECIMENS[b])
 
           reduced = build { yield(:reduced, SPECIMENS[a], SPECIMENS[b]) }
           next if reduced.nil?
@@ -456,8 +457,25 @@ RSpec.describe 'subtype relation vs runtime behaviour' do
       end)
     end
 
+    # Hash-to-Hash pairs are out of scope here, because for them `&` is not a
+    # reduction of the unreduced node at all. HashClass#& implements its own
+    # operation — the SHARED key set with each shared field met — while
+    # Conjunction.build would produce a sequential And that runs one record after
+    # the other, and a record drops the keys it does not declare, so the second
+    # sees a hash the first already stripped. The two are different operations, not
+    # a node and its reduction, so a mismatch here says nothing.
+    #
+    # NOTE this leaves Hash meets unpoliced by the property laws. MEET above cannot
+    # take over: it is gated on #value_preserving?, which a record is not (it drops
+    # undeclared keys), and ungating it would report a deliberate choice as a
+    # failure — a Hash meet keeps only the SHARED keys, so it forgets a key either
+    # side required and can accept what that side rejects
+    # (`Hash[name: String, age: Integer] & Hash[name?: String, age: Integer, ...]`
+    # admits `{age: 42}`, which the left rejects). Hash meets are covered instead by
+    # the worked examples in spec/intersection_spec.rb and the typed-keys specs.
     it 'preserves the accepted set when reducing an & intersection' do
-      report(self.class.fidelity_violations('&') do |form, a, b|
+      hash_pair = ->(a, b) { a.is_a?(Plumb::HashClass) && b.is_a?(Plumb::HashClass) }
+      report(self.class.fidelity_violations('&', skip_pair: hash_pair) do |form, a, b|
         form == :reduced ? a & b : Plumb::Conjunction.build(a, b)
       end)
     end

--- a/spec/subtype_laws_spec.rb
+++ b/spec/subtype_laws_spec.rb
@@ -103,7 +103,7 @@ RSpec.describe 'subtype relation vs runtime behaviour' do
     'Nil' => Types::Nil,
     'Boolean' => Types::Boolean,
 
-    # refinements — ranges (inclusive AND exclusive: range_in_range? must respect
+    # refinements — ranges (inclusive AND exclusive: Interval must respect
     # #exclude_end?, and Constraint.intersect_ranges already does)
     'Integer[0..100]' => Types::Integer[0..100],
     'Integer[10..]' => Types::Integer[10..],

--- a/spec/type_subtyping_spec.rb
+++ b/spec/type_subtyping_spec.rb
@@ -599,9 +599,28 @@ RSpec.describe 'subtyping: Plumb::Subtyping.subtype? and #<=' do
       # producer is wider (extra keys are fine)
       expect { STypes::Hash[name: STypes::String, age: STypes::Integer] >> STypes::Hash[name: STypes::String] }
         .not_to raise_error
-      # the key the producer lacks is optional for the consumer
+    end
+
+    # The producer's #call emits only its declared keys, so no stray `age` can reach
+    # the consumer — safe, and it composes. The SCHEMA-level relation stays strict
+    # (see the sibling example below): as a description of incoming data the producer
+    # also covers hashes carrying an `age` of any type, which the consumer would
+    # reject. check_composable! is what distinguishes the two, by retrying against
+    # HashClass#closed.
+    it 'allows a producer to omit a key the consumer only accepts optionally' do
       expect { STypes::Hash[name: STypes::String] >> STypes::Hash[name: STypes::String, age?: STypes::Integer] }
         .not_to raise_error
+    end
+
+    it 'still refuses that pair as a SCHEMA subtype relation' do
+      producer = STypes::Hash[name: STypes::String]
+      consumer = STypes::Hash[name: STypes::String, age?: STypes::Integer]
+      expect(Plumb::Subtyping.subtype?(producer, consumer)).to be(false)
+      # the witness: an `age` the producer never constrained
+      expect(producer.resolve(name: 'a', age: 'nope').valid?).to be(true)
+      expect(consumer.resolve(name: 'a', age: 'nope').valid?).to be(false)
+      # but what the producer EMITS is closed, and that does relate
+      expect(Plumb::Subtyping.subtype?(producer.closed, consumer)).to be(true)
     end
 
     it 'does not check value-converting steps (transform/build bypass the check)' do

--- a/spec/type_subtyping_spec.rb
+++ b/spec/type_subtyping_spec.rb
@@ -71,10 +71,24 @@ RSpec.describe 'subtyping: Plumb::Subtyping.subtype? and #<=' do
       expect(STypes::Integer[0..20] <= STypes::Integer[1..10]).to be(false)
     end
 
+    # A literal matches with Ruby's `==`, so a numeric literal describes every
+    # numeric spelling of its value — `Types::Any[5]` accepts `5`, `5.0`, `5r` and
+    # `BigDecimal('5')`. Its class is therefore Numeric, not Integer, and a type
+    # that admits only Integers is NOT above it.
     it 'places literals within ranges and classes' do
-      expect(STypes::Any[5] <= STypes::Integer[1..10]).to be(true)
-      expect(STypes::Any[5] <= STypes::Integer).to be(true)
-      expect(STypes::Any[50] <= STypes::Integer[1..10]).to be(false)
+      expect(STypes::Any[5] <= STypes::Any[1..10]).to be(true)
+      expect(STypes::Any[5] <= STypes::Numeric).to be(true)
+      expect(STypes::Any[50] <= STypes::Any[1..10]).to be(false)
+
+      # An Integer-based refinement rejects `5.0`, which `Any[5]` accepts.
+      expect(STypes::Any[5] <= STypes::Integer).to be(false)
+      expect(STypes::Any[5] <= STypes::Integer[1..10]).to be(false)
+      expect(STypes::Integer[1..10].resolve(5.0).valid?).to be(false)
+      expect(STypes::Any[5].resolve(5.0).valid?).to be(true)
+
+      # Non-numeric literals have no cross-class equality to account for.
+      expect(STypes::Any['a'] <= STypes::String).to be(true)
+      expect(STypes::Any['a'] <= STypes::String[/a/]).to be(true)
     end
   end
 
@@ -620,8 +634,12 @@ RSpec.describe 'subtyping: Plumb::Subtyping.subtype? and #<=' do
     it 'normalizes raw classes/values on either side' do
       expect(Plumb::Subtyping.subtype?(STypes::Integer, ::Numeric)).to be(true)
       expect(Plumb::Subtyping.subtype?(::Integer, STypes::Numeric)).to be(true)
-      expect(Plumb::Subtyping.subtype?(5, STypes::Integer)).to be(true)
+      # A raw value normalizes to the same value match as `Types::Value[5]`, which
+      # matches by `==` — so it describes Numeric rather than Integer.
+      expect(Plumb::Subtyping.subtype?(5, STypes::Numeric)).to be(true)
+      expect(Plumb::Subtyping.subtype?(5, STypes::Integer)).to be(false)
       expect(Plumb::Subtyping.subtype?(5, STypes::String)).to be(false)
+      expect(Plumb::Subtyping.subtype?('a', STypes::String)).to be(true)
     end
   end
 


### PR DESCRIPTION
Adds a property spec that checks the subtype relation against what types actually
accept at runtime, then fixes what it found. The relation was sound in the
algebra but disagreed with the data in ~20 places, and because four consumers act
on its verdict, several of those disagreements changed *validation results*:

| consumer | effect of a wrong verdict |
|---|---|
| `Optimizer.reduce_step` / `redundant_refinement?` | deletes a runtime check |
| `Optimizer.reduce_union` | drops a union branch |
| `Subtyping.intersect` | drops a meet operand |
| `Subtyping.check_composable!` | admits an always-failing chain |

`spec/subtype_laws_spec.rb` states 14 laws over a 48-type × 44-witness grid.
Violations went **556 → 0**. Existing suite: 1048 examples, 0 failures.

## The laws

Soundness (`a <= b` implies `b` accepts everything `a` does), equivalence,
join/meet, sequence, and **reduction fidelity** — each operator compared against
its *unreduced* form (`And`/`Or`/`Conjunction.build`), so a reduction that
changes the accepted set is caught. That last one has the teeth: dropping the
right side of a chain doesn't widen it past its left, so it's invisible to a
"never accepts more than `a`" check.

## Fixes, by root cause

**Bogus `#==` (5 types).** `Equality#==` compares class + `#children`, but
`Deferred` (no children — so *every* deferred equalled every other), `Policy`,
`Metadata` and `TaggedHash` keep identity in ivars. `subtype?` and the Optimizer
short-circuit on `==` *before* their `value_preserving?`/`identity_wrapper?`
guards, so a bogus equality was enough to drop a branch. `Equality#==` also now
uses `instance_of?` — with `is_a?` a parent equalled its subclass but not the
reverse, which silently discarded `FilteredHashMap`'s filtering and
`ConcurrentArrayClass`'s concurrency from a meet.

**`resolve_base_types` inaccuracy.** `:not` reported the classes it *excludes*;
`:range` reported its member type. Also fixed `Interface` being fooled by both.

**`disjoint_atomic?` judged the wrong domain.** It read produced types, so
`Types::String & Types::Not[Types::Integer]` collapsed to `Never` though every
String satisfies both. Now only asks nodes with a *stable domain*.

**`Not` was covariant.** Negation is contravariant.

**Record subtyping.** `Types::Hash >> Hash[_: Integer]` deleted its consumer
(`Types::Array >> Array[Integer]` correctly raises — the two disagreed). Pattern
keys were invisible to the relation on both sides while `#call` enforced them.

**`Constraint`** reported `value_preserving?` unconditionally, so
`Types::Integer | String.transform(::Integer, :to_i)[0..150]` discarded the
coercion. It now follows its base, and projects onto what it produces.

**`fuse_with` changed validity.** A function whose block returns the wrong type
yields an invalid Result alone, but was *valid* once fused — the seam dropped the
intermediate output check. Subsumption proves the declared output is acceptable,
not that `fn` returns it.

**Totality.** `Types::Data[...].resolve([1])` raised `TypeError` (`#to_h` exists
on Array but raises); `Types::Any.where(upcase: 'X').resolve(5)` raised
`NoMethodError`. Both return invalid Results now.

Plus: regexp options were ignored (`/a/i` and `/a/` were interchangeable, so a
union dropped the matching branch); `range_in_class?` read one endpoint;
`range_in_range?` ignored `#exclude_end?`; `Pipeline` was type-flow-transparent
but a subtype of nothing; union distribution rebuilt operands in the wrong order.

## Behaviour changes worth reviewing

- **Literals follow Ruby `==`.** `Types::Value[5]` accepts `5.0`, so it describes
  `Numeric`, not `Integer`. `subtype?(5, Types::Integer)` is now `false` and
  `subtype?(5, Types::Numeric)` `true`. Runtime matching is unchanged. Two specs
  in `type_subtyping_spec.rb` asserted the old reading and were updated.
- **One literal representation.** `Types::Any[5]`, `Types::Value[5]` and
  `Composable.wrap(5)` all build a `ValueClass` — they already accepted identical
  values and emitted identical JSON Schema, but the algebra related them
  asymmetrically.
- **Records subtype strictly.** A schema describes hashes where its declared keys
  hold; extra keys are allowed but unconstrained. So
  `Hash[name: String] <= Hash[name: String, age?: Integer]` is `false` (witness
  `{name: "a", age: "boom"}`). This is the standard open-record rule, and it is
  transitive where the previous reading was not.
- **Composition keeps the permissive answer**, because there cleaning is a
  guarantee: `#call` emits only declared keys, so `check_composable!` retries
  against `HashClass#closed`. The `>>` above still composes.
- **`TaggedHash`** discriminators accept any single-literal node, not only a
  `Constraint` — so `tagged_by` now works with both `kind: 'event'` and
  `kind: Types::String['event']`.

## Not addressed

`HashClass#&` keeps only shared keys, so it drops a key either side required and
can accept what that side rejects. That's specced in three places as deliberate,
so it's left alone; the note in `subtype_laws_spec.rb` records that this leaves
Hash meets to the worked examples in `intersection_spec.rb`.

## Test plan

- `bundle exec rspec` — 1062 examples, 0 failures
- `spec/subtype_laws_spec.rb` — 14/14 laws green, no allowlist to regenerate
- `spec/fixtures/subtype_relation.yml` still passes, but several relations it
  records have changed meaning; worth a `REGENERATE_SNAPSHOTS=1` diff review

🤖 Generated with [Claude Code](https://claude.com/claude-code)
