### PR TITLE
Codec registries

### DIFF
--- a/README.md
+++ b/README.md
@@ -2091,6 +2091,34 @@ JSONPerson.to_json_schema
 # "dates" is described as { "type" => "object", "properties" => { "from" => { "type" => "string" }, ... } }
 ```
 
+#### Codec instances: a registry of pre-built pairs
+
+Composing a codec rewrites the whole type tree, so it belongs at boot — not on the path of every message. A codec _instance_ is a registry of `[decoder, encoder]` pairs, each built once by `register` and then looked up by key:
+
+```ruby
+CODECS = JSONCodec.new do |c|
+  c.register('person.created', Person)
+  c.register('company.created', Company)
+  c.register(Types::Date) # the key defaults to the type itself
+end
+
+CODECS.decode('person.created', payload)   # => a Person hash
+CODECS.encode('person.created', person)    # => JSON structures
+CODECS.decode(Types::Date, '2024-01-01')   # => Date
+```
+
+Keys are yours to choose — a message name, a content type, the type itself. `decode` and `encode` only `#parse`, so the rewrite is paid for once.
+
+An instance built with a block is frozen when the block returns. Without one it stays open, and `register` chains:
+
+```ruby
+registry = JSONCodec.new
+registry.register('day', Types::Date).register('person', Person)
+registry.freeze
+```
+
+`key?` asks what is registered; an unknown key raises `Plumb::Codec::NoEntryError` (a `KeyError`). Payloads are still validated by their type — a bad one raises `Plumb::ParseError` as usual.
+
 #### `Codec::Forms`: string-based formats
 
 The second built-in codec targets HTML forms, query strings and other formats where **every value arrives as a string**. Unlike `Codec::JSON` there are almost no native scalars: strings pass through, untyped containers recurse (Rack-style nested params), and everything else maps through an encoder with a strictly-patterned string input type — integers (`/\A-?\d+\z/`), floats, decimals, booleans (`"true"/"1"`, `"false"/"0"`, case-insensitive), ISO 8601 dates and times, scheme-prefixed URIs, and the empty string for `nil` (so `Types::Date | Types::Nil` decodes `''` to `nil`).

--- a/lib/plumb/codec.rb
+++ b/lib/plumb/codec.rb
@@ -197,6 +197,39 @@ module Plumb
       end
     end
 
+    Entry = Data.define(:decoder, :encoder)
+    NoEntryError = Class.new(KeyError)
+
+    def initialize(&)
+      @entries = {}
+      return unless block_given?
+
+      yield self
+      freeze
+    end
+
+    def freeze
+      @entries.freeze
+      super
+    end
+
+    # Named, not splatted: both sides are types that #parse, so a swapped pair would
+    # decode where it should encode without anything raising.
+    def register(key, type = key)
+      decoder, encoder = self.class.for(type)
+      @entries[key] = Entry.new(decoder:, encoder:)
+      self
+    end
+
+    def key?(key) = @entries.key?(key)
+
+    def decode(key, payload) = entry(key).decoder.parse(payload)
+    def encode(key, payload) = entry(key).encoder.parse(payload)
+
+    def inspect
+      %(#<#{self.class}:#{object_id} [#{@entries.size} entries]>)
+    end
+
     # The deep rewrite walker. Top-down, per node:
     #
     #   1. Static values, Or/And chains and transparent wrappers recurse into
@@ -463,12 +496,10 @@ module Plumb
         # constant) still rewrite their input once.
         input = enc.input_type_for(type)
         rewritten_input = @input_memo.fetch(type) do
-          begin
-            @input_stack.push(enc)
-            @input_memo[type] = visit(input, path + ["<#{enc.inspect} input>"])
-          ensure
-            @input_stack.pop
-          end
+          @input_stack.push(enc)
+          @input_memo[type] = visit(input, path + ["<#{enc.inspect} input>"])
+        ensure
+          @input_stack.pop
         end
 
         # Splice the input into the step unless it is the encoder's declared
@@ -662,7 +693,6 @@ module Plumb
                 'Register an encoder for it, or declare it with .noop.'
         end
       end
-
     end
 
     # ------------------------------------------------------------------
@@ -844,6 +874,12 @@ module Plumb
       # Format-neutral string encoders, shared with Codec::JSON.
       encoder DateEncoder, TimeEncoder, SymbolEncoder, DecimalEncoder
       encoder URIEncoder, HTTPURIEncoder, FileURIEncoder
+    end
+
+    private
+
+    def entry(key)
+      @entries.fetch(key) { raise NoEntryError, "no encoder/decoder registered for #{key}" }
     end
   end
 end

--- a/spec/codec_spec.rb
+++ b/spec/codec_spec.rb
@@ -200,6 +200,64 @@ module CodecSpecTypes
       end
     end
 
+    describe 'registry (Codec instances)' do
+      it 'decodes and encodes by key' do
+        registry = JSONCodec.new do |c|
+          c.register('person.created', Person)
+          c.register('day', Types::Date)
+        end
+
+        expect(registry.decode('person.created', ENCODED_PERSON)).to eq(PERSON)
+        expect(registry.encode('person.created', PERSON)).to eq(ENCODED_PERSON)
+        expect(registry.decode('day', '2024-01-01')).to eq(DATE)
+        expect(registry.encode('day', DATE)).to eq('2024-01-01')
+      end
+
+      it 'composes each pair ONCE, at registration' do
+        registry = JSONCodec.new { |c| c.register('person', Person) }
+
+        expect(JSONCodec).not_to receive(:for) # the rewrite already happened
+        3.times { expect(registry.decode('person', ENCODED_PERSON)).to eq(PERSON) }
+      end
+
+      it 'defaults the type to the key itself' do
+        registry = JSONCodec.new { |c| c.register(Company) }
+
+        company = registry.decode(Company, { name: 'ACME', founded: '2024-01-01' })
+        expect(company).to eq(Company.new(name: 'ACME', founded: DATE))
+        expect(registry.encode(Company, company)).to eq({ name: 'ACME', founded: '2024-01-01' })
+      end
+
+      it 'reports what it knows, and raises a KeyError for what it does not' do
+        registry = JSONCodec.new { |c| c.register('day', Types::Date) }
+
+        expect(registry.key?('day')).to be(true)
+        expect(registry.key?('nope')).to be(false)
+        expect { registry.decode('nope', 'x') }
+          .to raise_error(Plumb::Codec::NoEntryError, %r{no encoder/decoder registered for nope})
+        expect { registry.encode('nope', DATE) }.to raise_error(KeyError) # rescuable either way
+      end
+
+      it 'still validates the payload' do
+        registry = JSONCodec.new { |c| c.register('day', Types::Date) }
+
+        expect { registry.decode('day', 'not-a-date') }.to raise_error(Plumb::ParseError)
+        expect(registry.decode('day', '2024-01-01')).to eq(DATE)
+      end
+
+      it 'freezes when built with a block, and stays open without one' do
+        sealed = JSONCodec.new { |c| c.register('day', Types::Date) }
+        expect(sealed).to be_frozen
+        expect { sealed.register('late', Types::String) }.to raise_error(FrozenError)
+
+        open = JSONCodec.new
+        expect(open).not_to be_frozen
+        expect(open.register('day', Types::Date)).to be(open) # chainable
+        expect(open.decode('day', '2024-01-01')).to eq(DATE)
+        expect { open.freeze.register('late', Types::String) }.to raise_error(FrozenError)
+      end
+    end
+
     describe 'composition with any type (scalar roots)' do
       it 'decodes a matched scalar' do
         expect((JSONCodec >> Types::Date).parse('2024-01-01')).to eq(DATE)


### PR DESCRIPTION
## What

Make `Plumb::Codec` behaviour class-level only.

```ruby
# Plumb::Codec::JSON is not instantiated here
DecodedPerson = Plumb::Codec::JSON >> Person
```

And make codec instances work as configurable registries that can store decoder/encoder pairs for arbitrary keys and types

```ruby
# register serializer at boot
Serializer = Plumb::Codec::JSON.new do |s|
  # use the type as key
  s.register Person
  
  # or provide an arbitrary key
  s.register 'events.orders.placed', Orders::Placed
end
```

Now the registry can be used to encode/decode types at runtime

```ruby
person = Serializer.decode(Person, json_data)
json_data = Serializer.encode(Person, person)

# using custom key
event = Serializer.decode('events.orders.placed', json_event_data)
json_event_data = Serializer.encode('events.orders.placed', event)
```

## Why

So that apps don't need to reinvent codec registries for their own types.